### PR TITLE
Pgz 86/feature/add transaction status

### DIFF
--- a/alembic/versions/a1b2c3d4e5f6_add_transaction_status.py
+++ b/alembic/versions/a1b2c3d4e5f6_add_transaction_status.py
@@ -1,0 +1,34 @@
+"""add transaction status field
+
+Revision ID: a1b2c3d4e5f6
+Revises: 3c8e2f1a9d47
+Create Date: 2026-04-10 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, Sequence[str], None] = "3c8e2f1a9d47"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add status column to transaction table. Existing records default to CONFIRMED."""
+    op.add_column(
+        "transaction",
+        sa.Column("status", sa.String(10), nullable=False, server_default="PENDING"),
+    )
+    # Existing records were accepted before this workflow existed
+    op.execute("UPDATE transaction SET status = 'CONFIRMED'")
+
+
+def downgrade() -> None:
+    """Remove status column from transaction table."""
+    op.drop_column("transaction", "status")

--- a/app/database/events.py
+++ b/app/database/events.py
@@ -25,9 +25,7 @@ def transaction_metrics_after_flush(session: Session, _flush_context: object) ->
 
     affected: Set[Tuple[Transaction, Transaction | None]] = set()
 
-    for obj in session.new:
-        if isinstance(obj, Transaction):
-            affected.add((obj, None))
+    # New transactions start as PENDING — no metrics recalculation needed
 
     for obj in session.dirty:
         if not isinstance(obj, Transaction):
@@ -36,6 +34,14 @@ def transaction_metrics_after_flush(session: Session, _flush_context: object) ->
             continue
 
         insp = inspect(obj)
+
+        status_hist = insp.attrs.status.history
+        old_status = status_hist.deleted[0] if status_hist.deleted else obj.status
+        new_status = obj.status
+
+        # Only recalculate when CONFIRMED is involved (transition to/from CONFIRMED or edit of CONFIRMED)
+        if old_status != "CONFIRMED" and new_status != "CONFIRMED":
+            continue
 
         old_tx: Transaction | None = None
         date_hist = insp.attrs.date.history
@@ -46,7 +52,7 @@ def transaction_metrics_after_flush(session: Session, _flush_context: object) ->
         affected.add((obj, old_tx))
 
     for obj in session.deleted:
-        if isinstance(obj, Transaction):
+        if isinstance(obj, Transaction) and obj.status == "CONFIRMED":
             old = copy(obj)
             affected.add((old, old))
 

--- a/app/enum/balance.py
+++ b/app/enum/balance.py
@@ -37,3 +37,11 @@ class SortOrder(StrEnum):
 
     ASC = "asc"
     DESC = "desc"
+
+
+class TransactionStatus(StrEnum):
+    """Enum for transaction status."""
+
+    PENDING = "PENDING"
+    CONFIRMED = "CONFIRMED"
+    REJECTED = "REJECTED"

--- a/app/errors/balance.py
+++ b/app/errors/balance.py
@@ -47,3 +47,47 @@ class InvalidPaymentMethodException(HTTPException):
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Invalid payment method",
         )
+
+
+class TransactionStatusForbiddenException(HTTPException):
+    """403 - Admin tried to set a status other than PENDING."""
+
+    def __init__(self):
+        """Exception raised when admin sets a status other than PENDING."""
+        super().__init__(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admins can only set transaction status to PENDING",
+        )
+
+
+class InvalidTransactionStatusTransitionException(HTTPException):
+    """422 - Admin tried to authorize a non-REJECTED transaction."""
+
+    def __init__(self):
+        """Exception raised when admin tries to resubmit a non-REJECTED transaction."""
+        super().__init__(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Admins can only re-submit REJECTED transactions to PENDING",
+        )
+
+
+class TransactionEditForbiddenException(HTTPException):
+    """403 - Admin tried to edit a non-REJECTED transaction."""
+
+    def __init__(self):
+        """Exception raised when admin tries to edit a non-REJECTED transaction."""
+        super().__init__(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admins can only edit REJECTED transactions",
+        )
+
+
+class TransactionDeleteForbiddenException(HTTPException):
+    """403 - Admin tried to delete a non-REJECTED transaction."""
+
+    def __init__(self):
+        """Exception raised when admin tries to delete a non-REJECTED transaction."""
+        super().__init__(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admins can only delete REJECTED transactions",
+        )

--- a/app/models/balance.py
+++ b/app/models/balance.py
@@ -15,5 +15,6 @@ class Transaction(Base):
     type = Column(String(10), nullable=True)
     description = Column(String(255), nullable=True)
     payment_method = Column(String(50), nullable=False)
+    status = Column(String(10), nullable=False, default="PENDING")
 
     __table_args__ = (Index("ix_transaction_date", "date"),)

--- a/app/repositories/balance.py
+++ b/app/repositories/balance.py
@@ -131,9 +131,17 @@ class BalanceRepository(DBRepository):
 
         return q.all()
 
-    def count_transactions_in_range(self, start_dt: datetime, end_dt: datetime) -> int:
+    def count_transactions_in_range(
+        self,
+        start_dt: datetime,
+        end_dt: datetime,
+        status: Optional[str] = None,
+    ) -> int:
         """Count transactions in a given date range."""
-        return self.db.query(Transaction).filter(Transaction.date >= start_dt, Transaction.date <= end_dt).count()
+        q = self.db.query(Transaction).filter(Transaction.date >= start_dt, Transaction.date <= end_dt)
+        if status is not None:
+            q = q.filter(Transaction.status == status)
+        return q.count()
 
     def list_transactions_in_range(
         self,
@@ -143,9 +151,13 @@ class BalanceRepository(DBRepository):
         offset: int,
         sort_by: TransactionSortBy,
         sort_order: SortOrder,
+        status: Optional[str] = None,
     ) -> list[Transaction]:
         """List transactions in a given date range."""
         q = self.db.query(Transaction).filter(Transaction.date >= start_dt, Transaction.date <= end_dt)
+
+        if status is not None:
+            q = q.filter(Transaction.status == status)
 
         sort_column_map = {
             TransactionSortBy.DATE: Transaction.date,

--- a/app/repositories/transaction_metrics.py
+++ b/app/repositories/transaction_metrics.py
@@ -47,6 +47,7 @@ class TransactionMetricsRepository(DBRepository):
         base_filter = (
             Transaction.date >= start_d,
             Transaction.date <= end_d,
+            Transaction.status == "CONFIRMED",
         )
 
         metrics = self._fetch_period_metrics(base_filter)

--- a/app/routers/balance.py
+++ b/app/routers/balance.py
@@ -12,6 +12,7 @@ from app.schemas.balance import (
     BalanceTransactionsResponseSchema,
     BalanceTrendQuerySchema,
     BalanceTrendResponseSchema,
+    TransactionAuthorizationSchema,
     TransactionPatchSchema,
     TransactionResponseSchema,
     TransactionSchema,
@@ -58,10 +59,10 @@ def create_transaction(
 def delete_transaction(
     reference: str = Path(description="Transaction reference"),
     service: BalanceService = Depends(ServiceFactory.balance_service),
-    _user: AuthUser = Depends(RequiresAuth([Role.OWNER])),
+    user: AuthUser = Depends(RequiresAuth([Role.OWNER, Role.ADMIN])),
 ) -> ActionSuccess:
     """Delete a transaction."""
-    service.delete_transaction(reference)
+    service.delete_transaction(reference, user.role)
     return {"message": f"Transaction '{reference}' was successfully deleted."}
 
 
@@ -70,10 +71,25 @@ def update_transaction(
     reference: str = Path(description="Transaction reference"),
     body: TransactionPatchSchema = Body(..., description="Transaction data"),
     service: BalanceService = Depends(ServiceFactory.balance_service),
-    _user: AuthUser = Depends(RequiresAuth([Role.OWNER])),
+    user: AuthUser = Depends(RequiresAuth([Role.OWNER, Role.ADMIN])),
 ) -> TransactionResponseSchema:
     """Update a transaction."""
-    return service.update_transaction(reference, body)
+    return service.update_transaction(reference, body, user.role)
+
+
+@router.post(
+    "/transaction/{reference}/authorization",
+    response_model=TransactionResponseSchema,
+    status_code=status.HTTP_200_OK,
+)
+def authorize_transaction(
+    reference: str = Path(description="Transaction reference"),
+    body: TransactionAuthorizationSchema = Body(..., description="New status"),
+    service: BalanceService = Depends(ServiceFactory.balance_service),
+    user: AuthUser = Depends(RequiresAuth([Role.OWNER, Role.ADMIN])),
+) -> TransactionResponseSchema:
+    """Approve, reject or resubmit a transaction."""
+    return service.authorize_transaction(reference, body.status, user.role)
 
 
 @router.get(
@@ -131,4 +147,5 @@ def get_balance_transactions(
         limit=params.limit,
         sort_by=params.sort_by,
         sort_order=params.sort_order,
+        status=params.status,
     )

--- a/app/schemas/balance.py
+++ b/app/schemas/balance.py
@@ -4,7 +4,7 @@ from typing import Annotated, Optional
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from pydantic.alias_generators import to_camel
 
-from app.enum.balance import PaymentMethod, PeriodType, SortOrder, TransactionSortBy, Type
+from app.enum.balance import PaymentMethod, PeriodType, SortOrder, TransactionSortBy, TransactionStatus, Type
 from app.errors.transaction_metrics import InvalidMetricsPeriodException
 from app.schemas.types import RequestUTCDatetime
 
@@ -33,6 +33,12 @@ class TransactionPatchSchema(BaseModel):
     amount: Optional[float] = None
     description: Optional[str] = None
     payment_method: Optional[PaymentMethod] = None
+
+
+class TransactionAuthorizationSchema(BaseModel):
+    """Schema for authorizing a transaction status change."""
+
+    status: TransactionStatus = Field(..., description="New status: CONFIRMED, REJECTED, or PENDING")
 
 
 class BalanceMetricsQuerySchema(BaseModel):
@@ -121,6 +127,11 @@ class BalanceTransactionsQuerySchema(BaseModel):
     month: Optional[int] = Field(None, ge=1, le=12, description="Month number (1-12)")
     year: Optional[int] = Field(None, ge=2000, le=2100, description="Year (e.g., 2026)")
 
+    status: Optional[TransactionStatus] = Field(
+        default=None,
+        description="Filter by status: PENDING, CONFIRMED, REJECTED",
+    )
+
     page: Annotated[int, Field(default=1, ge=1, description="Page number starting at 1")] = 1
     limit: Annotated[int, Field(default=10, ge=1, le=100, description="Records per page (max 100)")] = 10
 
@@ -168,6 +179,7 @@ class TransactionResponseSchema(BaseModel):
     type: Type = Field(..., description="Type of the transaction")
     description: str = Field(..., description="Description of the transaction")
     payment_method: PaymentMethod = Field(..., description="Payment method")
+    status: TransactionStatus = Field(..., description="Approval status of the transaction")
 
     @field_validator("description", mode="before")
     @classmethod

--- a/app/services/balance.py
+++ b/app/services/balance.py
@@ -2,12 +2,17 @@ import math
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
-from app.enum.balance import PaymentMethod, PeriodType, SortOrder, TransactionSortBy, Type
+from app.enum.auth import Role
+from app.enum.balance import PaymentMethod, PeriodType, SortOrder, TransactionSortBy, TransactionStatus, Type
 from app.errors.balance import (
     InvalidDescriptionLengthException,
     InvalidPaymentMethodException,
+    InvalidTransactionStatusTransitionException,
     InvalidTransactionTypeException,
+    TransactionDeleteForbiddenException,
+    TransactionEditForbiddenException,
     TransactionNotFoundException,
+    TransactionStatusForbiddenException,
 )
 from app.models.balance import Transaction
 from app.repositories.balance import BalanceRepository
@@ -81,24 +86,31 @@ class BalanceService:
             type=data.type,
             description=data.description,
             payment_method=data.payment_method,
+            status=TransactionStatus.PENDING,
         )
         return self.repository.create_transaction(transaction)
 
-    def delete_transaction(self, reference: str):
+    def delete_transaction(self, reference: str, user_role: str) -> None:
         """Delete a transaction."""
 
         transaction = self.repository.get_by_reference(reference)
         if not transaction:
             raise TransactionNotFoundException(reference)
 
+        if user_role == Role.ADMIN and transaction.status != TransactionStatus.REJECTED:
+            raise TransactionDeleteForbiddenException
+
         self.repository.delete_transaction(transaction)
 
-    def update_transaction(self, reference: str, data: TransactionSchema) -> TransactionResponseSchema:
+    def update_transaction(self, reference: str, data: TransactionSchema, user_role: str) -> TransactionResponseSchema:
         """Update a transaction."""
 
         transaction = self.repository.get_by_reference(reference)
         if not transaction:
             raise TransactionNotFoundException(reference)
+
+        if user_role == Role.ADMIN and transaction.status != TransactionStatus.REJECTED:
+            raise TransactionEditForbiddenException
 
         if data.amount is not None:
             transaction.amount = data.amount
@@ -113,6 +125,22 @@ class BalanceService:
                 raise InvalidPaymentMethodException
             transaction.payment_method = data.payment_method
 
+        return self.repository.update_transaction(transaction)
+
+    def authorize_transaction(self, reference: str, new_status: TransactionStatus, user_role: str) -> TransactionResponseSchema:
+        """Authorize (approve/reject/resubmit) a transaction."""
+
+        transaction = self.repository.get_by_reference(reference)
+        if not transaction:
+            raise TransactionNotFoundException(reference)
+
+        if user_role == Role.ADMIN:
+            if new_status != TransactionStatus.PENDING:
+                raise TransactionStatusForbiddenException
+            if transaction.status != TransactionStatus.REJECTED:
+                raise InvalidTransactionStatusTransitionException
+
+        transaction.status = new_status
         return self.repository.update_transaction(transaction)
 
     def get_metrics(self, month: int | None = None, year: int | None = None) -> BalanceMetricsSimpleResponseSchema:
@@ -240,6 +268,7 @@ class BalanceService:
         limit: int = 10,
         sort_by: TransactionSortBy = TransactionSortBy.DATE,
         sort_order: SortOrder = SortOrder.DESC,
+        status: TransactionStatus | None = None,
     ) -> BalanceTransactionsResponseSchema:
         """Get transactions for a given period with pagination & sorting."""
 
@@ -251,6 +280,7 @@ class BalanceService:
         total = self.repository.count_transactions_in_range(
             start_dt=start_dt,
             end_dt=end_dt,
+            status=status,
         )
 
         rows = self.repository.list_transactions_in_range(
@@ -260,6 +290,7 @@ class BalanceService:
             offset=offset,
             sort_by=sort_by,
             sort_order=sort_order,
+            status=status,
         )
 
         return BalanceTransactionsResponseSchema(

--- a/tests/mocks/balance_repository_mock.py
+++ b/tests/mocks/balance_repository_mock.py
@@ -18,6 +18,7 @@ class BalanceRepositoryMock:
                 type="debit",
                 description="Initial mock transaction",
                 payment_method="cash",
+                status="CONFIRMED",
             ),
         ]
         self.mapping: dict[tuple[str, int, int | None, int | None], object] = {}
@@ -59,9 +60,12 @@ class BalanceRepositoryMock:
         """Return rows for bulk key lookup (trend endpoint)."""
         return [row for k in keys if (row := self.mapping.get((period_type, k.year, k.month, k.week)))]
 
-    def count_transactions_in_range(self, start_dt: datetime, end_dt: datetime) -> int:
+    def count_transactions_in_range(self, start_dt: datetime, end_dt: datetime, status=None) -> int:
         """Count transactions in a given date range (inclusive end)."""
-        return sum(1 for t in self.transactions if start_dt <= t.date <= end_dt)
+        filtered = [t for t in self.transactions if start_dt <= t.date <= end_dt]
+        if status is not None:
+            filtered = [t for t in filtered if t.status == status]
+        return len(filtered)
 
     def list_transactions_in_range(
         self,
@@ -71,9 +75,12 @@ class BalanceRepositoryMock:
         offset: int,
         sort_by: TransactionSortBy,
         sort_order: SortOrder,
+        status=None,
     ) -> list[Transaction]:
         """List transactions in a given date range."""
         filtered = [t for t in self.transactions if start_dt <= t.date <= end_dt]
+        if status is not None:
+            filtered = [t for t in filtered if t.status == status]
 
         sort_by_val = sort_by.value if isinstance(sort_by, TransactionSortBy) else sort_by or "date"
         sort_order_val = sort_order.value if isinstance(sort_order, SortOrder) else sort_order or "desc"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
@@ -7,6 +8,7 @@ import app.database.events
 from app.dependencies import RepositoryFactory
 from app.enum.auth import Role
 from app.main import app
+from app.models.users import User
 from tests.mocks import UserRepositoryMock
 from tests.mocks.balance_repository_mock import BalanceRepositoryMock
 
@@ -28,6 +30,7 @@ def disable_metrics_listener(monkeypatch):
 @pytest.fixture(autouse=True)
 def reset_state():
     user_repo_mock.users = [_initial_user]
+    _initial_transaction.status = "CONFIRMED"
     balance_repo_mock.transactions = [_initial_transaction]
     balance_repo_mock.mapping = {}
 
@@ -61,6 +64,48 @@ def authorized_client():
         response = client.post(
             "/pegazzo/internal/auth/login",
             json={"username": "testuser", "password": "password123", "role": Role.OWNER},
+        )
+
+    client.cookies.set("access_token_cookie", response.cookies.get("access_token_cookie"))
+    client.cookies.set("refresh_token_cookie", response.cookies.get("refresh_token_cookie"))
+    client.headers.update(
+        {
+            "X-CSRF-ACCESS": response.cookies.get("csrf_access_token"),
+            "X-CSRF-REFRESH": response.cookies.get("csrf_refresh_token"),
+        },
+    )
+
+    return client
+
+
+@pytest.fixture
+def admin_authorized_client():
+    """Client with valid JWT cookie for role 'admin'."""
+    app.dependency_overrides = {
+        RepositoryFactory.user_repository: lambda: user_repo_mock,
+        RepositoryFactory.balance_repository: lambda: balance_repo_mock,
+    }
+
+    admin_user = User(
+        username="adminuser",
+        name="Admin",
+        surnames="User",
+        password="hashed_password",
+        role_id=2,
+        role=user_repo_mock.roles["administrador"],
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+    user_repo_mock.users.append(admin_user)
+
+    client = TestClient(app)
+    client.balance_repo = balance_repo_mock
+    client.user_repo = user_repo_mock
+
+    with patch("app.utils.auth.AuthUtils.verify_password", return_value=True):
+        response = client.post(
+            "/pegazzo/internal/auth/login",
+            json={"username": "adminuser", "password": "password123"},
         )
 
     client.cookies.set("access_token_cookie", response.cookies.get("access_token_cookie"))

--- a/tests/unit/database/test_events.py
+++ b/tests/unit/database/test_events.py
@@ -9,9 +9,10 @@ from app.repositories.transaction_metrics import TransactionMetricsRepository
 from app.schemas.dto.periods import PeriodKey
 
 
-def make_tx(tx_dt: datetime) -> Transaction:
+def make_tx(tx_dt: datetime, status: str = "CONFIRMED") -> Transaction:
     tx = Transaction()
     tx.date = tx_dt
+    tx.status = status
     return tx
 
 
@@ -27,42 +28,44 @@ def mock_session(*, new=None, dirty=None, deleted=None, is_modified=True) -> Ses
 
 @patch.object(TransactionMetricsRepository, "recalc_period")
 @patch("app.database.events.get_affected_periods")
-def test_new_transaction_triggers_recalc(
+def test_new_transaction_does_not_trigger_recalc(
     mock_get_periods,
     mock_recalc_period,
 ):
+    """New transactions are always PENDING — no metrics recalculation."""
     tx_dt = datetime(2026, 1, 10, 10, 0, 0, tzinfo=timezone.utc)
-    tx = make_tx(tx_dt)
-
-    mock_get_periods.return_value = {
-        PeriodKey(period_type="month", year=2026, month=1, week=None),
-    }
+    tx = make_tx(tx_dt, status="PENDING")
 
     session = mock_session(new=[tx])
 
     transaction_metrics_after_flush(session, None)
 
-    mock_get_periods.assert_called_once_with(tx_dt)
-    mock_recalc_period.assert_called_once()
+    mock_get_periods.assert_not_called()
+    mock_recalc_period.assert_not_called()
 
 
 @patch.object(TransactionMetricsRepository, "recalc_period")
 @patch("app.database.events.get_affected_periods")
-def test_dirty_transaction_with_date_change_triggers_old_and_new_periods(
+def test_dirty_confirmed_transaction_with_date_change_triggers_old_and_new_periods(
     mock_get_periods,
     mock_recalc_period,
 ):
+    """Editing a CONFIRMED transaction's date triggers recalc for both old and new periods."""
     old_dt = datetime(2025, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
     new_dt = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
 
-    tx = make_tx(new_dt)
+    tx = make_tx(new_dt, status="CONFIRMED")
 
-    history = MagicMock()
-    history.has_changes.return_value = True
-    history.deleted = [old_dt]
+    date_history = MagicMock()
+    date_history.has_changes.return_value = True
+    date_history.deleted = [old_dt]
+
+    status_history = MagicMock()
+    status_history.deleted = []
 
     insp = MagicMock()
-    insp.attrs.date.history = history
+    insp.attrs.date.history = date_history
+    insp.attrs.status.history = status_history
 
     with patch("app.database.events.inspect", return_value=insp):
         mock_get_periods.side_effect = [
@@ -80,12 +83,67 @@ def test_dirty_transaction_with_date_change_triggers_old_and_new_periods(
 
 @patch.object(TransactionMetricsRepository, "recalc_period")
 @patch("app.database.events.get_affected_periods")
-def test_deleted_transaction_triggers_recalc(
+def test_dirty_pending_transaction_does_not_trigger_recalc(
     mock_get_periods,
     mock_recalc_period,
 ):
+    """Editing a PENDING transaction does not trigger metrics recalculation."""
+    tx = make_tx(datetime(2026, 1, 10, tzinfo=timezone.utc), status="PENDING")
+
+    status_history = MagicMock()
+    status_history.deleted = []
+
+    insp = MagicMock()
+    insp.attrs.date.history.has_changes.return_value = False
+    insp.attrs.status.history = status_history
+
+    with patch("app.database.events.inspect", return_value=insp):
+        session = mock_session(dirty=[tx])
+        transaction_metrics_after_flush(session, None)
+
+    mock_get_periods.assert_not_called()
+    mock_recalc_period.assert_not_called()
+
+
+@patch.object(TransactionMetricsRepository, "recalc_period")
+@patch("app.database.events.get_affected_periods")
+def test_status_transition_to_confirmed_triggers_recalc(
+    mock_get_periods,
+    mock_recalc_period,
+):
+    """Transitioning a transaction to CONFIRMED triggers metrics recalculation."""
+    tx_dt = datetime(2026, 3, 5, tzinfo=timezone.utc)
+    tx = make_tx(tx_dt, status="CONFIRMED")
+
+    date_history = MagicMock()
+    date_history.has_changes.return_value = False
+
+    status_history = MagicMock()
+    status_history.deleted = ["PENDING"]  # old status was PENDING
+
+    insp = MagicMock()
+    insp.attrs.date.history = date_history
+    insp.attrs.status.history = status_history
+
+    mock_get_periods.return_value = {PeriodKey("month", 2026, 3, None)}
+
+    with patch("app.database.events.inspect", return_value=insp):
+        session = mock_session(dirty=[tx])
+        transaction_metrics_after_flush(session, None)
+
+    mock_get_periods.assert_called_once_with(tx_dt)
+    mock_recalc_period.assert_called_once()
+
+
+@patch.object(TransactionMetricsRepository, "recalc_period")
+@patch("app.database.events.get_affected_periods")
+def test_deleted_confirmed_transaction_triggers_recalc(
+    mock_get_periods,
+    mock_recalc_period,
+):
+    """Deleting a CONFIRMED transaction triggers metrics recalculation."""
     tx_dt = datetime(2026, 2, 5, 12, 0, 0, tzinfo=timezone.utc)
-    tx = make_tx(tx_dt)
+    tx = make_tx(tx_dt, status="CONFIRMED")
 
     mock_get_periods.return_value = {
         PeriodKey("month", 2026, 2, None),
@@ -99,6 +157,24 @@ def test_deleted_transaction_triggers_recalc(
     assert mock_get_periods.call_count == 2
 
     mock_recalc_period.assert_called_once()
+
+
+@patch.object(TransactionMetricsRepository, "recalc_period")
+@patch("app.database.events.get_affected_periods")
+def test_deleted_pending_transaction_does_not_trigger_recalc(
+    mock_get_periods,
+    mock_recalc_period,
+):
+    """Deleting a PENDING transaction does NOT trigger metrics recalculation."""
+    tx_dt = datetime(2026, 2, 5, 12, 0, 0, tzinfo=timezone.utc)
+    tx = make_tx(tx_dt, status="PENDING")
+
+    session = mock_session(deleted=[tx])
+
+    transaction_metrics_after_flush(session, None)
+
+    mock_get_periods.assert_not_called()
+    mock_recalc_period.assert_not_called()
 
 
 def test_does_nothing_when_flag_is_set():

--- a/tests/unit/routers/test_balance_router.py
+++ b/tests/unit/routers/test_balance_router.py
@@ -513,6 +513,7 @@ class TestBalanceRouter:
                 type="debit",
                 description="Tx 1",
                 payment_method="cash",
+                status="CONFIRMED",
             ),
             Transaction(
                 amount=200,
@@ -521,6 +522,7 @@ class TestBalanceRouter:
                 type="debit",
                 description="Tx 2",
                 payment_method="cash",
+                status="CONFIRMED",
             ),
             Transaction(
                 amount=300,
@@ -529,6 +531,7 @@ class TestBalanceRouter:
                 type="debit",
                 description="Tx 3",
                 payment_method="cash",
+                status="CONFIRMED",
             ),
         ]
 
@@ -559,6 +562,7 @@ class TestBalanceRouter:
                 type="debit",
                 description="Bulk",
                 payment_method="cash",
+                status="CONFIRMED",
             )
             for i in range(15)
         ]
@@ -591,6 +595,7 @@ class TestBalanceRouter:
                 type="debit",
                 description="",
                 payment_method="cash",
+                status="CONFIRMED",
             ),
             Transaction(
                 amount=150,
@@ -599,6 +604,7 @@ class TestBalanceRouter:
                 type="debit",
                 description="",
                 payment_method="cash",
+                status="CONFIRMED",
             ),
             Transaction(
                 amount=50,
@@ -607,6 +613,7 @@ class TestBalanceRouter:
                 type="debit",
                 description="",
                 payment_method="cash",
+                status="CONFIRMED",
             ),
         ]
 
@@ -633,6 +640,7 @@ class TestBalanceRouter:
                 type="debit",
                 description="",
                 payment_method="cash",
+                status="CONFIRMED",
             ),
             Transaction(
                 amount=10,
@@ -641,6 +649,7 @@ class TestBalanceRouter:
                 type="debit",
                 description="",
                 payment_method="cash",
+                status="CONFIRMED",
             ),
             Transaction(
                 amount=10,
@@ -649,6 +658,7 @@ class TestBalanceRouter:
                 type="debit",
                 description="",
                 payment_method="cash",
+                status="CONFIRMED",
             ),
         ]
 
@@ -726,3 +736,144 @@ class TestBalanceRouter:
     def test_get_transactions_unauthorized(self, client):
         r = client.get("/pegazzo/management/balance/transactions?period=year&year=2026")
         assert r.status_code == 401
+
+    def test_get_transactions_with_status_filter(self, authorized_client):
+        """Transactions list accepts optional status filter."""
+        r = authorized_client.get(
+            "/pegazzo/management/balance/transactions?period=year&year=2026&status=CONFIRMED",
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert "transactions" in data
+
+    def test_get_transactions_invalid_status_422(self, authorized_client):
+        """Invalid status value returns 422."""
+        r = authorized_client.get(
+            "/pegazzo/management/balance/transactions?period=year&year=2026&status=INVALID",
+        )
+        assert r.status_code == 422
+
+    # Authorization endpoint tests
+
+    def test_authorize_transaction_owner_confirms(self, authorized_client):
+        """Owner can confirm a PENDING transaction."""
+        reference = "MOCK_REF_001"
+        authorized_client.balance_repo.transactions[0].status = "PENDING"
+
+        r = authorized_client.post(
+            f"/pegazzo/management/balance/transaction/{reference}/authorization",
+            json={"status": "CONFIRMED"},
+        )
+        assert r.status_code == 200
+        assert r.json()["status"] == "CONFIRMED"
+
+    def test_authorize_transaction_owner_rejects(self, authorized_client):
+        """Owner can reject a PENDING transaction."""
+        reference = "MOCK_REF_001"
+        authorized_client.balance_repo.transactions[0].status = "PENDING"
+
+        r = authorized_client.post(
+            f"/pegazzo/management/balance/transaction/{reference}/authorization",
+            json={"status": "REJECTED"},
+        )
+        assert r.status_code == 200
+        assert r.json()["status"] == "REJECTED"
+
+    def test_authorize_transaction_not_found(self, authorized_client):
+        """Returns 404 when reference does not exist."""
+        r = authorized_client.post(
+            "/pegazzo/management/balance/transaction/NOEXIST/authorization",
+            json={"status": "CONFIRMED"},
+        )
+        assert r.status_code == 404
+
+    def test_authorize_transaction_invalid_status_422(self, authorized_client):
+        """Returns 422 for invalid status value."""
+        r = authorized_client.post(
+            "/pegazzo/management/balance/transaction/MOCK_REF_001/authorization",
+            json={"status": "INVALID"},
+        )
+        assert r.status_code == 422
+
+    def test_authorize_transaction_unauthorized(self, client):
+        """Unauthenticated request returns 401."""
+        r = client.post(
+            "/pegazzo/management/balance/transaction/MOCK_REF_001/authorization",
+            json={"status": "CONFIRMED"},
+        )
+        assert r.status_code == 401
+
+    def test_authorize_transaction_admin_resubmits_rejected(self, admin_authorized_client):
+        """Admin can resubmit a REJECTED transaction to PENDING."""
+        reference = "MOCK_REF_001"
+        admin_authorized_client.balance_repo.transactions[0].status = "REJECTED"
+
+        r = admin_authorized_client.post(
+            f"/pegazzo/management/balance/transaction/{reference}/authorization",
+            json={"status": "PENDING"},
+        )
+        assert r.status_code == 200
+        assert r.json()["status"] == "PENDING"
+
+    def test_authorize_transaction_admin_cannot_confirm_403(self, admin_authorized_client):
+        """Admin cannot confirm a transaction."""
+        reference = "MOCK_REF_001"
+        admin_authorized_client.balance_repo.transactions[0].status = "PENDING"
+
+        r = admin_authorized_client.post(
+            f"/pegazzo/management/balance/transaction/{reference}/authorization",
+            json={"status": "CONFIRMED"},
+        )
+        assert r.status_code == 403
+
+    def test_authorize_transaction_admin_pending_on_pending_422(self, admin_authorized_client):
+        """Admin cannot resubmit a PENDING transaction (not REJECTED)."""
+        reference = "MOCK_REF_001"
+        admin_authorized_client.balance_repo.transactions[0].status = "PENDING"
+
+        r = admin_authorized_client.post(
+            f"/pegazzo/management/balance/transaction/{reference}/authorization",
+            json={"status": "PENDING"},
+        )
+        assert r.status_code == 422
+
+    # Admin delete/edit permission tests
+
+    def test_delete_transaction_admin_rejected_success(self, admin_authorized_client):
+        """Admin can delete a REJECTED transaction."""
+        reference = "MOCK_REF_001"
+        admin_authorized_client.balance_repo.transactions[0].status = "REJECTED"
+
+        r = admin_authorized_client.delete(f"/pegazzo/management/balance/transaction/{reference}")
+        assert r.status_code == 200
+
+    def test_delete_transaction_admin_confirmed_403(self, admin_authorized_client):
+        """Admin cannot delete a CONFIRMED transaction."""
+        reference = "MOCK_REF_001"
+        admin_authorized_client.balance_repo.transactions[0].status = "CONFIRMED"
+
+        r = admin_authorized_client.delete(f"/pegazzo/management/balance/transaction/{reference}")
+        assert r.status_code == 403
+
+    def test_update_transaction_admin_rejected_success(self, admin_authorized_client):
+        """Admin can edit a REJECTED transaction."""
+        reference = "MOCK_REF_001"
+        admin_authorized_client.balance_repo.transactions[0].status = "REJECTED"
+
+        r = admin_authorized_client.patch(
+            f"/pegazzo/management/balance/transaction/{reference}",
+            json={"amount": 999},
+        )
+        assert r.status_code == 200
+        assert r.json()["amount"] == 999
+
+    def test_update_transaction_admin_confirmed_403(self, admin_authorized_client):
+        """Admin cannot edit a CONFIRMED transaction."""
+        reference = "MOCK_REF_001"
+        admin_authorized_client.balance_repo.transactions[0].status = "CONFIRMED"
+
+        r = admin_authorized_client.patch(
+            f"/pegazzo/management/balance/transaction/{reference}",
+            json={"amount": 999},
+        )
+        assert r.status_code == 403

--- a/tests/unit/services/test_balance_service.py
+++ b/tests/unit/services/test_balance_service.py
@@ -6,10 +6,15 @@ from unittest.mock import Mock, patch
 import pytest
 from pydantic import ValidationError
 
-from app.enum.balance import PaymentMethod, PeriodType, SortOrder, TransactionSortBy, Type
+from app.enum.auth import Role
+from app.enum.balance import PaymentMethod, PeriodType, SortOrder, TransactionSortBy, TransactionStatus, Type
 from app.errors.balance import (
     InvalidDescriptionLengthException,
+    InvalidTransactionStatusTransitionException,
+    TransactionDeleteForbiddenException,
+    TransactionEditForbiddenException,
     TransactionNotFoundException,
+    TransactionStatusForbiddenException,
 )
 from app.errors.transaction_metrics import TransactionMetricsPeriodError
 from app.models.balance import Transaction
@@ -45,10 +50,11 @@ class TestBalanceService:
         """Test deleting a transaction by reference."""
         # Arrange
         mock_transaction = Mock()
+        mock_transaction.status = TransactionStatus.CONFIRMED
         self.mock_repo.get_by_reference.return_value = mock_transaction
 
         # Act
-        self.service.delete_transaction("ABC123")
+        self.service.delete_transaction("ABC123", Role.OWNER)
 
         # Assert
         self.mock_repo.get_by_reference.assert_called_once_with("ABC123")
@@ -61,7 +67,35 @@ class TestBalanceService:
 
         # Act & Assert
         with pytest.raises(TransactionNotFoundException):
-            self.service.delete_transaction("NOEXIST")
+            self.service.delete_transaction("NOEXIST", Role.OWNER)
+
+    def test_delete_transaction_admin_rejected_success(self):
+        """Admin can delete a REJECTED transaction."""
+        mock_transaction = Mock()
+        mock_transaction.status = TransactionStatus.REJECTED
+        self.mock_repo.get_by_reference.return_value = mock_transaction
+
+        self.service.delete_transaction("ABC123", Role.ADMIN)
+
+        self.mock_repo.delete_transaction.assert_called_once_with(mock_transaction)
+
+    def test_delete_transaction_admin_confirmed_forbidden(self):
+        """Admin cannot delete a CONFIRMED transaction."""
+        mock_transaction = Mock()
+        mock_transaction.status = TransactionStatus.CONFIRMED
+        self.mock_repo.get_by_reference.return_value = mock_transaction
+
+        with pytest.raises(TransactionDeleteForbiddenException):
+            self.service.delete_transaction("ABC123", Role.ADMIN)
+
+    def test_delete_transaction_admin_pending_forbidden(self):
+        """Admin cannot delete a PENDING transaction."""
+        mock_transaction = Mock()
+        mock_transaction.status = TransactionStatus.PENDING
+        self.mock_repo.get_by_reference.return_value = mock_transaction
+
+        with pytest.raises(TransactionDeleteForbiddenException):
+            self.service.delete_transaction("ABC123", Role.ADMIN)
 
     def test_get_transaction_success(self):
         """Test returning a transaction by reference."""
@@ -159,6 +193,7 @@ class TestBalanceService:
             amount=100,
             description="Old description",
             payment_method=PaymentMethod.CASH,
+            status="CONFIRMED",
         )
 
         self.mock_repo.get_by_reference.return_value = existing_tx
@@ -170,7 +205,7 @@ class TestBalanceService:
             payment_method=PaymentMethod.CASH,
         )
 
-        result = self.service.update_transaction("REF123", update_schema)
+        result = self.service.update_transaction("REF123", update_schema, Role.OWNER)
 
         self.mock_repo.get_by_reference.assert_called_once_with("REF123")
         self.mock_repo.update_transaction.assert_called_once_with(existing_tx)
@@ -187,6 +222,7 @@ class TestBalanceService:
             amount=100,
             description="Original",
             payment_method=PaymentMethod.CASH,
+            status="CONFIRMED",
         )
 
         self.mock_repo.get_by_reference.return_value = existing_tx
@@ -198,7 +234,7 @@ class TestBalanceService:
             payment_method=None,
         )
 
-        result = self.service.update_transaction("REF123", update_schema)
+        result = self.service.update_transaction("REF123", update_schema, Role.OWNER)
 
         assert result.amount == 100
         assert result.description == "Only description updated"
@@ -216,7 +252,7 @@ class TestBalanceService:
         )
 
         with pytest.raises(TransactionNotFoundException):
-            self.service.update_transaction("NOEXIST", update_schema)
+            self.service.update_transaction("NOEXIST", update_schema, Role.OWNER)
 
     def test_update_transaction_invalid_description_length(self):
         """Test error when updating transaction with long description."""
@@ -228,6 +264,7 @@ class TestBalanceService:
             amount=100,
             description="Old",
             payment_method=PaymentMethod.CASH,
+            status="CONFIRMED",
         )
 
         self.mock_repo.get_by_reference.return_value = existing_tx
@@ -239,7 +276,50 @@ class TestBalanceService:
         )
 
         with pytest.raises(InvalidDescriptionLengthException):
-            self.service.update_transaction("REF123", update_schema)
+            self.service.update_transaction("REF123", update_schema, Role.OWNER)
+
+    def test_update_transaction_admin_rejected_success(self):
+        """Admin can update a REJECTED transaction."""
+        existing_tx = Transaction(
+            reference="REF123",
+            amount=100,
+            description="Old",
+            payment_method=PaymentMethod.CASH,
+            status="REJECTED",
+        )
+        self.mock_repo.get_by_reference.return_value = existing_tx
+        self.mock_repo.update_transaction.side_effect = lambda t: t
+
+        result = self.service.update_transaction("REF123", TransactionPatchSchema(amount=200), Role.ADMIN)
+        assert result.amount == 200
+
+    def test_update_transaction_admin_confirmed_forbidden(self):
+        """Admin cannot update a CONFIRMED transaction."""
+        existing_tx = Transaction(
+            reference="REF123",
+            amount=100,
+            description="Old",
+            payment_method=PaymentMethod.CASH,
+            status="CONFIRMED",
+        )
+        self.mock_repo.get_by_reference.return_value = existing_tx
+
+        with pytest.raises(TransactionEditForbiddenException):
+            self.service.update_transaction("REF123", TransactionPatchSchema(amount=200), Role.ADMIN)
+
+    def test_update_transaction_admin_pending_forbidden(self):
+        """Admin cannot update a PENDING transaction."""
+        existing_tx = Transaction(
+            reference="REF123",
+            amount=100,
+            description="Old",
+            payment_method=PaymentMethod.CASH,
+            status="PENDING",
+        )
+        self.mock_repo.get_by_reference.return_value = existing_tx
+
+        with pytest.raises(TransactionEditForbiddenException):
+            self.service.update_transaction("REF123", TransactionPatchSchema(amount=200), Role.ADMIN)
 
     def test_get_month_year_metrics_returns_zero_when_no_data(self):
         # Arrange
@@ -568,7 +648,7 @@ class TestBalanceService:
         assert key_arg.month == 1
         assert key_arg.week is None
 
-        self.mock_repo.count_transactions_in_range.assert_called_once_with(start_dt=start_dt, end_dt=end_dt)
+        self.mock_repo.count_transactions_in_range.assert_called_once_with(start_dt=start_dt, end_dt=end_dt, status=None)
         self.mock_repo.list_transactions_in_range.assert_called_once_with(
             start_dt=start_dt,
             end_dt=end_dt,
@@ -576,6 +656,7 @@ class TestBalanceService:
             offset=10,
             sort_by=TransactionSortBy.DATE,
             sort_order=SortOrder.DESC,
+            status=None,
         )
 
         assert result.pagination.page == 2
@@ -644,8 +725,8 @@ class TestBalanceService:
         start_dt = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
         end_dt = datetime(2026, 1, 31, 23, 59, 59, tzinfo=timezone.utc)
 
-        tx1 = Transaction(reference="TRX-001", amount=100, date=start_dt, type="debit", description="A", payment_method="cash")
-        tx2 = Transaction(reference="TRX-002", amount=200, date=end_dt, type="debit", description="B", payment_method="cash")
+        tx1 = Transaction(reference="TRX-001", amount=100, date=start_dt, type="debit", description="A", payment_method="cash", status="CONFIRMED")
+        tx2 = Transaction(reference="TRX-002", amount=200, date=end_dt, type="debit", description="B", payment_method="cash", status="CONFIRMED")
 
         self.mock_repo.count_transactions_in_range.return_value = 2
         self.mock_repo.list_transactions_in_range.return_value = [tx1, tx2]
@@ -673,4 +754,74 @@ class TestBalanceService:
             offset=0,
             sort_by=TransactionSortBy.AMOUNT,
             sort_order=SortOrder.ASC,
+            status=None,
         )
+
+    def test_authorize_transaction_owner_confirms(self):
+        """Owner can confirm a PENDING transaction."""
+        tx = Transaction(reference="REF1", amount=100, type="debit", description="X", payment_method="cash", status="PENDING")
+        self.mock_repo.get_by_reference.return_value = tx
+        self.mock_repo.update_transaction.side_effect = lambda t: t
+
+        result = self.service.authorize_transaction("REF1", TransactionStatus.CONFIRMED, Role.OWNER)
+
+        assert result.status == TransactionStatus.CONFIRMED
+
+    def test_authorize_transaction_owner_rejects(self):
+        """Owner can reject any transaction."""
+        tx = Transaction(reference="REF1", amount=100, type="debit", description="X", payment_method="cash", status="CONFIRMED")
+        self.mock_repo.get_by_reference.return_value = tx
+        self.mock_repo.update_transaction.side_effect = lambda t: t
+
+        result = self.service.authorize_transaction("REF1", TransactionStatus.REJECTED, Role.OWNER)
+
+        assert result.status == TransactionStatus.REJECTED
+
+    def test_authorize_transaction_admin_resubmits_rejected(self):
+        """Admin can resubmit a REJECTED transaction to PENDING."""
+        tx = Transaction(reference="REF1", amount=100, type="debit", description="X", payment_method="cash", status="REJECTED")
+        self.mock_repo.get_by_reference.return_value = tx
+        self.mock_repo.update_transaction.side_effect = lambda t: t
+
+        result = self.service.authorize_transaction("REF1", TransactionStatus.PENDING, Role.ADMIN)
+
+        assert result.status == TransactionStatus.PENDING
+
+    def test_authorize_transaction_admin_cannot_confirm(self):
+        """Admin cannot set status to CONFIRMED."""
+        tx = Transaction(reference="REF1", amount=100, type="debit", description="X", payment_method="cash", status="PENDING")
+        self.mock_repo.get_by_reference.return_value = tx
+
+        with pytest.raises(TransactionStatusForbiddenException):
+            self.service.authorize_transaction("REF1", TransactionStatus.CONFIRMED, Role.ADMIN)
+
+    def test_authorize_transaction_admin_cannot_reject(self):
+        """Admin cannot set status to REJECTED."""
+        tx = Transaction(reference="REF1", amount=100, type="debit", description="X", payment_method="cash", status="PENDING")
+        self.mock_repo.get_by_reference.return_value = tx
+
+        with pytest.raises(TransactionStatusForbiddenException):
+            self.service.authorize_transaction("REF1", TransactionStatus.REJECTED, Role.ADMIN)
+
+    def test_authorize_transaction_admin_cannot_resubmit_pending(self):
+        """Admin cannot resubmit a PENDING transaction (only REJECTED)."""
+        tx = Transaction(reference="REF1", amount=100, type="debit", description="X", payment_method="cash", status="PENDING")
+        self.mock_repo.get_by_reference.return_value = tx
+
+        with pytest.raises(InvalidTransactionStatusTransitionException):
+            self.service.authorize_transaction("REF1", TransactionStatus.PENDING, Role.ADMIN)
+
+    def test_authorize_transaction_admin_cannot_resubmit_confirmed(self):
+        """Admin cannot resubmit a CONFIRMED transaction."""
+        tx = Transaction(reference="REF1", amount=100, type="debit", description="X", payment_method="cash", status="CONFIRMED")
+        self.mock_repo.get_by_reference.return_value = tx
+
+        with pytest.raises(InvalidTransactionStatusTransitionException):
+            self.service.authorize_transaction("REF1", TransactionStatus.PENDING, Role.ADMIN)
+
+    def test_authorize_transaction_not_found(self):
+        """Raises 404 if transaction does not exist."""
+        self.mock_repo.get_by_reference.return_value = None
+
+        with pytest.raises(TransactionNotFoundException):
+            self.service.authorize_transaction("NOEXIST", TransactionStatus.CONFIRMED, Role.OWNER)


### PR DESCRIPTION
## Ticket 🎫

### [PGZ-86: [MTH] Add transaction status field and approval workflow endpoints](https://kapibaras.atlassian.net/jira/software/c/projects/PGZ/boards/15?selectedIssue=PGZ-86)

## Type of change ♻️                                                                                                                                                                    
- [x] ✨ Feature
- [ ] 🐛 Bugfix                                                                                                                                                                          
- [ ] ⚡ Improvement
- [ ] 🔧 Chore                                                                                                                                                                         
  
## What was done ❓
- Added `status` field (`PENDING`, `CONFIRMED`, `REJECTED`) to the `Transaction` model and Alembic migration (existing records migrated to `CONFIRMED`)
- Created `POST /management/balance/transaction/{reference}/authorization` endpoint with role-based transition rules (OWNER can confirm/reject, ADMIN can only re-submit rejected      
transactions)
- Updated `PATCH` and `DELETE` transaction endpoints to allow ADMIN access on `REJECTED` transactions only
- Added optional `status` filter to `GET /management/balance/transactions` list endpoint
- Updated metrics recalculation to only trigger on `CONFIRMED` transactions

## Checklist 📋

- [x] ⏭️ PR Branch has been **rebased** with `main`.
- [x] 🧪 Each change has a corresponding **Unit Test covering it**.
- [x] 🔎 Code and Functionality has been **self-reviewed** by the author.
- [x] 📝 PR Template has been **filled out**.
- [x] 🗃️ **Updated migrations** from changes on database schema. (If necessary)
- [x] ✏️ Endpoints and Schemas have complete and **well-written documentation**. (If necessary)
- [x] 📷 Evidence of changes on the endpoints (requests and response) (If necessary)

<img width="1393" height="717" alt="Captura de pantalla 2026-04-17 160541" src="https://github.com/user-attachments/assets/136a99bf-b2d5-4f5f-912a-992d9c0ad96b" />
<img width="1414" height="740" alt="Captura de pantalla 2026-04-17 160203" src="https://github.com/user-attachments/assets/fcf5501b-e075-4bf0-8188-4bbe7f264286" />
