### PR TITLE
Pgz 81/feature/add car id field

### DIFF
--- a/alembic/versions/b7c9e2f4a8d1_add_car_id_to_transaction.py
+++ b/alembic/versions/b7c9e2f4a8d1_add_car_id_to_transaction.py
@@ -1,0 +1,32 @@
+"""add car_id to transaction table
+
+Revision ID: b7c9e2f4a8d1
+Revises: a1b2c3d4e5f6
+Create Date: 2026-04-19 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b7c9e2f4a8d1"
+down_revision: Union[str, Sequence[str], None] = "a1b2c3d4e5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add nullable car_id column to transaction table."""
+    op.add_column(
+        "transaction",
+        sa.Column("car_id", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Remove car_id column from transaction table."""
+    op.drop_column("transaction", "car_id")

--- a/app/models/balance.py
+++ b/app/models/balance.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Index, Numeric, String
+from sqlalchemy import Column, Index, Integer, Numeric, String
 from sqlalchemy.sql import func
 from sqlalchemy.types import DateTime
 
@@ -16,5 +16,6 @@ class Transaction(Base):
     description = Column(String(255), nullable=True)
     payment_method = Column(String(50), nullable=False)
     status = Column(String(10), nullable=False, default="PENDING")
+    car_id = Column(Integer, nullable=True)
 
     __table_args__ = (Index("ix_transaction_date", "date"),)

--- a/app/routers/balance.py
+++ b/app/routers/balance.py
@@ -48,6 +48,8 @@ def create_transaction(
     _user: AuthUser = Depends(RequiresAuth([Role.OWNER, Role.ADMIN])),
 ) -> TransactionResponseSchema:
     """Create a new transaction."""
+    # TODO: Accept car_id (optional) as body parameter once the car module is implemented.
+    # Validate that car_id exists in the car table at that point.
     return service.create_transaction(data=body)
 
 
@@ -74,6 +76,8 @@ def update_transaction(
     user: AuthUser = Depends(RequiresAuth([Role.OWNER, Role.ADMIN])),
 ) -> TransactionResponseSchema:
     """Update a transaction."""
+    # TODO: Accept car_id (optional) as body parameter once the car module is implemented.
+    # Validate that car_id exists in the car table at that point.
     return service.update_transaction(reference, body, user.role)
 
 

--- a/app/schemas/balance.py
+++ b/app/schemas/balance.py
@@ -180,6 +180,7 @@ class TransactionResponseSchema(BaseModel):
     description: str = Field(..., description="Description of the transaction")
     payment_method: PaymentMethod = Field(..., description="Payment method")
     status: TransactionStatus = Field(..., description="Approval status of the transaction")
+    car_id: Optional[int] = Field(default=None, description="Associated car ID (nullable)")
 
     @field_validator("description", mode="before")
     @classmethod

--- a/tests/unit/routers/test_balance_router.py
+++ b/tests/unit/routers/test_balance_router.py
@@ -877,3 +877,44 @@ class TestBalanceRouter:
             json={"amount": 999},
         )
         assert r.status_code == 403
+
+    # car_id field tests
+
+    def test_create_transaction_response_has_car_id_null(self, authorized_client):
+        """POST /transaction response includes car_id as null."""
+        r = authorized_client.post(
+            "/pegazzo/management/balance/transaction",
+            json={
+                "amount": 500,
+                "type": "debit",
+                "description": "Test car_id",
+                "payment_method": "cash",
+            },
+        )
+        assert r.status_code == 201
+        assert r.json()["carId"] is None
+
+    def test_get_transaction_response_has_car_id_null(self, authorized_client):
+        """GET /transaction/{reference} response includes car_id as null."""
+        r = authorized_client.get("/pegazzo/management/balance/transaction/MOCK_REF_001")
+        assert r.status_code == 200
+        assert r.json()["carId"] is None
+
+    def test_update_transaction_response_has_car_id_null(self, authorized_client):
+        """PATCH /transaction/{reference} response includes car_id as null."""
+        r = authorized_client.patch(
+            "/pegazzo/management/balance/transaction/MOCK_REF_001",
+            json={"amount": 750},
+        )
+        assert r.status_code == 200
+        assert r.json()["carId"] is None
+
+    def test_list_transactions_response_has_car_id_null(self, authorized_client):
+        """GET /transactions response includes car_id as null in each transaction."""
+        r = authorized_client.get(
+            "/pegazzo/management/balance/transactions?period=year&year=2026",
+        )
+        assert r.status_code == 200
+        payload = r.json()
+        for tx in payload["transactions"]:
+            assert tx["carId"] is None


### PR DESCRIPTION
## Ticket 🎫

### [PGZ-81: [MTH] Add car_id field to Transaction model](https://kapibaras.atlassian.net/browse/PGZ-81)                       
## Type of change ♻️                                                                                                        ─
  
- [x] ✨ Feature                                                                                                              
- [ ] 🐛 Bugfix                                                                                                               
- [ ] ⚡ Improvement                                                                                                          
- [ ] 🔧 Chore

## What was done ❓

- Added `car_id` nullable column to the `Transaction` SQLAlchemy model
- Created Alembic migration to `ALTER TABLE transaction ADD COLUMN car_id INTEGER NULL` (reversible)
- Updated `TransactionResponseSchema` to include `car_id: Optional[int] = None` in all relevant endpoints (POST, GET, PATCH,
 LIST)
- Added `TODO` comments in `create_transaction` and `update_transaction` endpoints marking where `car_id` should be accepted
 once the car module is ready
- Added unit tests verifying `car_id` is returned as `null` in existing transaction responses

  ## Checklist 📋

  - [x] ⏭️ PR Branch has been **rebased** with `main`.
  - [x] 🧪 Each change has a corresponding **Unit Test covering it**.
  - [x] 🔎 Code and Functionality has been **self-reviewed** by the author.
  - [x] 📝 PR Template has been **filled out**.
  - [x] 🗃️ **Updated migrations** from changes on database schema. (If necessary)
  - [x] ✏️ Endpoints and Schemas have complete and **well-written documentation**. (If necessary)
  - [ ] 📷 Evidence of changes on the endpoints (requests and response) (If necessary)
