### PR TITLE
feat: Add category field to Transaction model and update CRUD endpoints

### DIFF
--- a/alembic/versions/c4d1f7e3b9a2_add_category_to_transaction.py
+++ b/alembic/versions/c4d1f7e3b9a2_add_category_to_transaction.py
@@ -1,0 +1,32 @@
+"""add category to transaction table
+
+Revision ID: c4d1f7e3b9a2
+Revises: a1b2c3d4e5f6
+Create Date: 2026-04-19 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c4d1f7e3b9a2"
+down_revision: Union[str, Sequence[str], None] = "a1b2c3d4e5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add category column to transaction table. Existing records default to 'Otro'."""
+    op.add_column(
+        "transaction",
+        sa.Column("category", sa.String(100), nullable=False, server_default="Otro"),
+    )
+
+
+def downgrade() -> None:
+    """Remove category column from transaction table."""
+    op.drop_column("transaction", "category")

--- a/app/models/balance.py
+++ b/app/models/balance.py
@@ -16,5 +16,6 @@ class Transaction(Base):
     description = Column(String(255), nullable=True)
     payment_method = Column(String(50), nullable=False)
     status = Column(String(10), nullable=False, default="PENDING")
+    category = Column(String(100), nullable=False, default="Otro")
 
     __table_args__ = (Index("ix_transaction_date", "date"),)

--- a/app/schemas/balance.py
+++ b/app/schemas/balance.py
@@ -25,6 +25,7 @@ class TransactionSchema(BaseModel):
     type: Type = Field(..., description="Type of the transaction")
     description: str = Field(..., description="Description of the transaction")
     payment_method: PaymentMethod = Field(..., description="Payment method of the transaction")
+    category: str = Field(..., min_length=1, max_length=100, description="Category of the transaction")
 
 
 class TransactionPatchSchema(BaseModel):
@@ -33,6 +34,7 @@ class TransactionPatchSchema(BaseModel):
     amount: Optional[float] = None
     description: Optional[str] = None
     payment_method: Optional[PaymentMethod] = None
+    category: Optional[str] = Field(default=None, min_length=1, max_length=100, description="Category of the transaction")
 
 
 class TransactionAuthorizationSchema(BaseModel):
@@ -180,6 +182,7 @@ class TransactionResponseSchema(BaseModel):
     description: str = Field(..., description="Description of the transaction")
     payment_method: PaymentMethod = Field(..., description="Payment method")
     status: TransactionStatus = Field(..., description="Approval status of the transaction")
+    category: str = Field(..., description="Category of the transaction")
 
     @field_validator("description", mode="before")
     @classmethod

--- a/app/services/balance.py
+++ b/app/services/balance.py
@@ -87,6 +87,7 @@ class BalanceService:
             description=data.description,
             payment_method=data.payment_method,
             status=TransactionStatus.PENDING,
+            category=data.category,
         )
         return self.repository.create_transaction(transaction)
 
@@ -124,6 +125,9 @@ class BalanceService:
             if data.payment_method not in PaymentMethod:
                 raise InvalidPaymentMethodException
             transaction.payment_method = data.payment_method
+
+        if data.category is not None:
+            transaction.category = data.category
 
         return self.repository.update_transaction(transaction)
 

--- a/tests/mocks/balance_repository_mock.py
+++ b/tests/mocks/balance_repository_mock.py
@@ -19,12 +19,24 @@ class BalanceRepositoryMock:
                 description="Initial mock transaction",
                 payment_method="cash",
                 status="CONFIRMED",
+                category="Otro",
             ),
         ]
         self.mapping: dict[tuple[str, int, int | None, int | None], object] = {}
 
     def reset(self):
-        self.transactions = self.transactions[:1]
+        self.transactions = [
+            Transaction(
+                amount=1000,
+                reference="MOCK_REF_001",
+                date=datetime.now(timezone.utc),
+                type="debit",
+                description="Initial mock transaction",
+                payment_method="cash",
+                status="CONFIRMED",
+                category="Otro",
+            )
+        ]
         self.mapping.clear()
 
     def get_by_reference(self, reference: str):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -16,7 +16,6 @@ user_repo_mock = UserRepositoryMock()
 _initial_user = user_repo_mock.users[0]
 
 balance_repo_mock = BalanceRepositoryMock()
-_initial_transaction = balance_repo_mock.transactions[0]
 
 
 @pytest.fixture(autouse=True)
@@ -30,9 +29,7 @@ def disable_metrics_listener(monkeypatch):
 @pytest.fixture(autouse=True)
 def reset_state():
     user_repo_mock.users = [_initial_user]
-    _initial_transaction.status = "CONFIRMED"
-    balance_repo_mock.transactions = [_initial_transaction]
-    balance_repo_mock.mapping = {}
+    balance_repo_mock.reset()
 
 
 @pytest.fixture

--- a/tests/unit/routers/test_balance_router.py
+++ b/tests/unit/routers/test_balance_router.py
@@ -81,6 +81,7 @@ class TestBalanceRouter:
                 "type": "debit",
                 "description": "Pago de material",
                 "payment_method": "cash",
+                "category": "Materiales",
             },
         )
         assert create_response.status_code == 201
@@ -117,6 +118,7 @@ class TestBalanceRouter:
                 "type": "debit",
                 "description": "Pago de material",
                 "payment_method": "cash",
+                "category": "Materiales",
             },
         )
 
@@ -160,6 +162,7 @@ class TestBalanceRouter:
                 "type": "debit",
                 "description": "To delete",
                 "payment_method": "cash",
+                "category": "Otro",
             },
         )
         reference = create_response.json()["reference"]
@@ -514,6 +517,7 @@ class TestBalanceRouter:
                 description="Tx 1",
                 payment_method="cash",
                 status="CONFIRMED",
+                category="Otro",
             ),
             Transaction(
                 amount=200,
@@ -523,6 +527,7 @@ class TestBalanceRouter:
                 description="Tx 2",
                 payment_method="cash",
                 status="CONFIRMED",
+                category="Otro",
             ),
             Transaction(
                 amount=300,
@@ -532,6 +537,7 @@ class TestBalanceRouter:
                 description="Tx 3",
                 payment_method="cash",
                 status="CONFIRMED",
+                category="Otro",
             ),
         ]
 
@@ -563,6 +569,7 @@ class TestBalanceRouter:
                 description="Bulk",
                 payment_method="cash",
                 status="CONFIRMED",
+                category="Otro",
             )
             for i in range(15)
         ]
@@ -596,6 +603,7 @@ class TestBalanceRouter:
                 description="",
                 payment_method="cash",
                 status="CONFIRMED",
+                category="Otro",
             ),
             Transaction(
                 amount=150,
@@ -605,6 +613,7 @@ class TestBalanceRouter:
                 description="",
                 payment_method="cash",
                 status="CONFIRMED",
+                category="Otro",
             ),
             Transaction(
                 amount=50,
@@ -614,6 +623,7 @@ class TestBalanceRouter:
                 description="",
                 payment_method="cash",
                 status="CONFIRMED",
+                category="Otro",
             ),
         ]
 
@@ -641,6 +651,7 @@ class TestBalanceRouter:
                 description="",
                 payment_method="cash",
                 status="CONFIRMED",
+                category="Otro",
             ),
             Transaction(
                 amount=10,
@@ -650,6 +661,7 @@ class TestBalanceRouter:
                 description="",
                 payment_method="cash",
                 status="CONFIRMED",
+                category="Otro",
             ),
             Transaction(
                 amount=10,
@@ -659,6 +671,7 @@ class TestBalanceRouter:
                 description="",
                 payment_method="cash",
                 status="CONFIRMED",
+                category="Otro",
             ),
         ]
 
@@ -877,3 +890,112 @@ class TestBalanceRouter:
             json={"amount": 999},
         )
         assert r.status_code == 403
+
+    # category field tests
+
+    def test_create_transaction_with_category_success(self, authorized_client):
+        """POST /transaction includes category in response."""
+        r = authorized_client.post(
+            "/pegazzo/management/balance/transaction",
+            json={
+                "amount": 800,
+                "type": "credit",
+                "description": "Ingreso cliente",
+                "payment_method": "cash",
+                "category": "Ventas",
+            },
+        )
+        assert r.status_code == 201
+        assert r.json()["category"] == "Ventas"
+
+    def test_create_transaction_without_category_422(self, authorized_client):
+        """POST /transaction without category returns 422."""
+        r = authorized_client.post(
+            "/pegazzo/management/balance/transaction",
+            json={
+                "amount": 800,
+                "type": "credit",
+                "description": "Ingreso cliente",
+                "payment_method": "cash",
+            },
+        )
+        assert r.status_code == 422
+
+    def test_create_transaction_empty_category_422(self, authorized_client):
+        """POST /transaction with empty category string returns 422."""
+        r = authorized_client.post(
+            "/pegazzo/management/balance/transaction",
+            json={
+                "amount": 800,
+                "type": "credit",
+                "description": "Ingreso cliente",
+                "payment_method": "cash",
+                "category": "",
+            },
+        )
+        assert r.status_code == 422
+
+    def test_create_transaction_category_too_long_422(self, authorized_client):
+        """POST /transaction with category > 100 chars returns 422."""
+        r = authorized_client.post(
+            "/pegazzo/management/balance/transaction",
+            json={
+                "amount": 800,
+                "type": "credit",
+                "description": "Ingreso cliente",
+                "payment_method": "cash",
+                "category": "x" * 101,
+            },
+        )
+        assert r.status_code == 422
+
+    def test_update_transaction_category_optional(self, authorized_client):
+        """PATCH /transaction without category succeeds (category is optional on edit)."""
+        r = authorized_client.patch(
+            "/pegazzo/management/balance/transaction/MOCK_REF_001",
+            json={"amount": 500},
+        )
+        assert r.status_code == 200
+
+    def test_update_transaction_category_updated(self, authorized_client):
+        """PATCH /transaction with category updates it in the response."""
+        authorized_client.balance_repo.transactions[0].category = "Otro"
+
+        r = authorized_client.patch(
+            "/pegazzo/management/balance/transaction/MOCK_REF_001",
+            json={"category": "Combustible"},
+        )
+        assert r.status_code == 200
+        assert r.json()["category"] == "Combustible"
+
+    def test_update_transaction_empty_category_422(self, authorized_client):
+        """PATCH /transaction with empty category returns 422."""
+        r = authorized_client.patch(
+            "/pegazzo/management/balance/transaction/MOCK_REF_001",
+            json={"category": ""},
+        )
+        assert r.status_code == 422
+
+    def test_update_transaction_category_too_long_422(self, authorized_client):
+        """PATCH /transaction with category > 100 chars returns 422."""
+        r = authorized_client.patch(
+            "/pegazzo/management/balance/transaction/MOCK_REF_001",
+            json={"category": "x" * 101},
+        )
+        assert r.status_code == 422
+
+    def test_get_transaction_response_has_category(self, authorized_client):
+        """GET /transaction/{reference} response includes category field."""
+        r = authorized_client.get("/pegazzo/management/balance/transaction/MOCK_REF_001")
+        assert r.status_code == 200
+        assert "category" in r.json()
+        assert r.json()["category"] == "Otro"
+
+    def test_list_transactions_response_has_category(self, authorized_client):
+        """GET /transactions includes category in each transaction."""
+        r = authorized_client.get(
+            "/pegazzo/management/balance/transactions?period=year&year=2026",
+        )
+        assert r.status_code == 200
+        for tx in r.json()["transactions"]:
+            assert "category" in tx

--- a/tests/unit/services/test_balance_service.py
+++ b/tests/unit/services/test_balance_service.py
@@ -122,6 +122,7 @@ class TestBalanceService:
             type=Type.DEBIT,
             description="Pago de material",
             payment_method=PaymentMethod.CASH,
+            category="Materiales",
         )
 
         # Mock
@@ -180,6 +181,7 @@ class TestBalanceService:
             type=Type.DEBIT,
             description=long_desc,
             payment_method=PaymentMethod.CASH,
+            category="Otro",
         )
 
         with pytest.raises(InvalidDescriptionLengthException):
@@ -725,8 +727,8 @@ class TestBalanceService:
         start_dt = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
         end_dt = datetime(2026, 1, 31, 23, 59, 59, tzinfo=timezone.utc)
 
-        tx1 = Transaction(reference="TRX-001", amount=100, date=start_dt, type="debit", description="A", payment_method="cash", status="CONFIRMED")
-        tx2 = Transaction(reference="TRX-002", amount=200, date=end_dt, type="debit", description="B", payment_method="cash", status="CONFIRMED")
+        tx1 = Transaction(reference="TRX-001", amount=100, date=start_dt, type="debit", description="A", payment_method="cash", status="CONFIRMED", category="Otro")
+        tx2 = Transaction(reference="TRX-002", amount=200, date=end_dt, type="debit", description="B", payment_method="cash", status="CONFIRMED", category="Otro")
 
         self.mock_repo.count_transactions_in_range.return_value = 2
         self.mock_repo.list_transactions_in_range.return_value = [tx1, tx2]


### PR DESCRIPTION
## Ticket 🎫

### [PGZ-83: [MTH] Add category field to Transaction model and update CRUD
endpoints](https://kapibaras.atlassian.net/browse/PGZ-83)

## Type of change ♻️

- [x] ✨ Feature

## What was done ❓

- Added `category` column (`String(100)`, NOT NULL, default `'Otro'`) to the `Transaction` SQLAlchemy model
- Created Alembic migration: `ALTER TABLE transaction ADD COLUMN category VARCHAR(100) NOT NULL DEFAULT 'Otro'` — existing  
records default to `'Otro'` (reversible)
- Updated `TransactionSchema` (POST): `category` required, non-empty string, max 100 characters
- Updated `TransactionPatchSchema` (PATCH): `category` optional, same validations if provided
- Updated `TransactionResponseSchema`: `category` included in all relevant responses (GET single, GET list)
- Refactored `BalanceRepositoryMock.reset()` to reconstruct the initial transaction fresh and updated `conftest.reset_state`
 to use it
- Added unit tests: required on create, optional on edit, max length validation, empty string rejection, and response field 
presence

## Checklist 📋

- [x] ⏭️ PR Branch has been **rebased** with `main`.
- [x] 🧪 Each change has a corresponding **Unit Test covering it**.
- [x] 🔎 Code and Functionality has been **self-reviewed** by the author.
- [x] 📝 PR Template has been **filled out**.
- [x] 🗃️ **Updated migrations** from changes on database schema. (If necessary)
- [x] ✏️ Endpoints and Schemas have complete and **well-written documentation**. (If necessary)
- [x] 📷 Evidence of changes on the endpoints (requests and response) (If necessary)

<img width="1388" height="928" alt="Captura de pantalla 2026-04-19 203548" src="https://github.com/user-attachments/assets/7d3f8707-127d-4922-8b1a-4b005a3b95bd" />
<img width="1389" height="894" alt="Captura de pantalla 2026-04-19 203616" src="https://github.com/user-attachments/assets/1ba21101-704a-4f7b-970c-b76318265f9f" />
<img width="1415" height="947" alt="Captura de pantalla 2026-04-19 203821" src="https://github.com/user-attachments/assets/39aa2bea-5899-44a7-ba81-f3667ca3edde" />

