### PR TITLE
feat: :sparkles: [MTH] Create transactions count endpoint

### DIFF
--- a/alembic/versions/bb39cb097284_merge_car_id_and_category_branches.py
+++ b/alembic/versions/bb39cb097284_merge_car_id_and_category_branches.py
@@ -1,0 +1,28 @@
+"""merge car_id and category branches
+
+Revision ID: bb39cb097284
+Revises: b7c9e2f4a8d1, c4d1f7e3b9a2
+Create Date: 2026-04-28 15:58:13.241754
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'bb39cb097284'
+down_revision: Union[str, Sequence[str], None] = ('b7c9e2f4a8d1', 'c4d1f7e3b9a2')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/app/routers/balance.py
+++ b/app/routers/balance.py
@@ -13,6 +13,8 @@ from app.schemas.balance import (
     BalanceTrendQuerySchema,
     BalanceTrendResponseSchema,
     TransactionAuthorizationSchema,
+    TransactionCountQuerySchema,
+    TransactionCountResponseSchema,
     TransactionPatchSchema,
     TransactionResponseSchema,
     TransactionSchema,
@@ -133,6 +135,20 @@ def get_trend(
 ) -> BalanceTrendResponseSchema:
     """Get historical balance data."""
     return service.get_historical(period=params.period, limit=params.limit)
+
+
+@router.get(
+    "/transactions/count",
+    response_model=TransactionCountResponseSchema,
+    status_code=status.HTTP_200_OK,
+)
+def get_transactions_count(
+    params: TransactionCountQuerySchema = Depends(TransactionCountQuerySchema),
+    service: BalanceService = Depends(ServiceFactory.balance_service),
+    _user: AuthUser = Depends(RequiresAuth([Role.OWNER, Role.ADMIN])),
+) -> TransactionCountResponseSchema:
+    """Get count of transactions for a given month/year with an optional status filter."""
+    return service.get_transactions_count(month=params.month, year=params.year, status=params.status)
 
 
 @router.get("/transactions", response_model=BalanceTransactionsResponseSchema, status_code=status.HTTP_200_OK)

--- a/app/schemas/balance.py
+++ b/app/schemas/balance.py
@@ -169,6 +169,24 @@ class BalanceTransactionsQuerySchema(BaseModel):
         return self
 
 
+class TransactionCountQuerySchema(BaseModel):
+    """Query params for GET /management/balance/transactions/count."""
+
+    month: int | None = Field(None, ge=1, le=12, description="Month number (1-12)")
+    year: int | None = Field(None, ge=2000, description="Year (e.g., 2026)")
+    status: Optional[TransactionStatus] = Field(
+        default=None,
+        description="Filter by status: PENDING, CONFIRMED, REJECTED",
+    )
+
+    @model_validator(mode="after")
+    def validate_month_year(self) -> "TransactionCountQuerySchema":
+        """Validate that month and year are provided together."""
+        if (self.month is None) ^ (self.year is None):
+            raise InvalidMetricsPeriodException
+        return self
+
+
 # * RESPONSE SCHEMAS * #
 
 
@@ -371,5 +389,14 @@ class BalanceTransactionsResponseSchema(BaseModel):
 
     transactions: list[TransactionResponseSchema] = Field(default_factory=list)
     pagination: PaginationSchema = Field(...)
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)
+
+
+class TransactionCountResponseSchema(BaseModel):
+    """Response schema for GET /management/balance/transactions/count."""
+
+    count: int = Field(..., ge=0, description="Number of transactions matching the filters")
+    period: BalancePeriodSchema = Field(..., description="Period for which the count is returned")
 
     model_config = ConfigDict(populate_by_name=True, alias_generator=to_camel)

--- a/app/services/balance.py
+++ b/app/services/balance.py
@@ -24,6 +24,7 @@ from app.schemas.balance import (
     BalanceTrendResponseSchema,
     ComparisonSchema,
     PaginationSchema,
+    TransactionCountResponseSchema,
     TransactionResponseSchema,
     TransactionSchema,
     WeeklyAveragesSchema,
@@ -261,6 +262,29 @@ class BalanceService:
             )
 
         return BalanceTrendResponseSchema(period_type=period, data=data)
+
+    def get_transactions_count(
+        self,
+        month: int | None = None,
+        year: int | None = None,
+        status: TransactionStatus | None = None,
+    ) -> TransactionCountResponseSchema:
+        """Count transactions for a given month/year with an optional status filter."""
+        if month is None and year is None:
+            now = datetime.now(timezone.utc)
+            month = now.month
+            year = now.year
+
+        key = PeriodKey(period_type=PeriodType.MONTH, year=year, month=month)
+        start_dt, end_dt = period_bounds_utc(key)
+
+        count = self.repository.count_transactions_in_range(
+            start_dt=start_dt,
+            end_dt=end_dt,
+            status=status,
+        )
+
+        return {"count": count, "period": {"month": month, "year": year}}
 
     def get_transactions(
         self,

--- a/tests/unit/routers/test_balance_router.py
+++ b/tests/unit/routers/test_balance_router.py
@@ -1026,3 +1026,101 @@ class TestBalanceRouter:
         payload = r.json()
         for tx in payload["transactions"]:
             assert tx["carId"] is None
+
+    # GET /transactions/count tests
+
+    def test_get_transactions_count_no_params_returns_current_month(self, authorized_client):
+        """No params → 200 with count for current month."""
+        r = authorized_client.get("/pegazzo/management/balance/transactions/count")
+        assert r.status_code == 200
+        payload = r.json()
+        assert "count" in payload
+        assert "period" in payload
+        assert isinstance(payload["count"], int)
+        assert payload["count"] >= 0
+
+    def test_get_transactions_count_with_month_year(self, authorized_client):
+        """Explicit month + year → 200 with correct period in response."""
+        r = authorized_client.get("/pegazzo/management/balance/transactions/count?month=1&year=2026")
+        assert r.status_code == 200
+        payload = r.json()
+        assert payload["period"]["month"] == 1
+        assert payload["period"]["year"] == 2026
+
+    def test_get_transactions_count_with_status_pending(self, authorized_client):
+        """status=PENDING filter is accepted and returns 200."""
+        r = authorized_client.get("/pegazzo/management/balance/transactions/count?status=PENDING")
+        assert r.status_code == 200
+        assert "count" in r.json()
+
+    def test_get_transactions_count_with_status_rejected(self, authorized_client):
+        """status=REJECTED filter is accepted and returns 200."""
+        r = authorized_client.get("/pegazzo/management/balance/transactions/count?status=REJECTED")
+        assert r.status_code == 200
+        assert "count" in r.json()
+
+    def test_get_transactions_count_with_status_confirmed(self, authorized_client):
+        """status=CONFIRMED filter is accepted and returns 200."""
+        r = authorized_client.get("/pegazzo/management/balance/transactions/count?status=CONFIRMED")
+        assert r.status_code == 200
+        assert "count" in r.json()
+
+    def test_get_transactions_count_only_month_400(self, authorized_client):
+        """Providing only month (no year) returns 400."""
+        r = authorized_client.get("/pegazzo/management/balance/transactions/count?month=4")
+        assert r.status_code == 400
+        assert "Invalid metrics period" in r.json()["detail"]
+
+    def test_get_transactions_count_only_year_400(self, authorized_client):
+        """Providing only year (no month) returns 400."""
+        r = authorized_client.get("/pegazzo/management/balance/transactions/count?year=2026")
+        assert r.status_code == 400
+        assert "Invalid metrics period" in r.json()["detail"]
+
+    def test_get_transactions_count_invalid_month_422(self, authorized_client):
+        """month out of range (0 or 13) returns 422."""
+        r = authorized_client.get("/pegazzo/management/balance/transactions/count?month=13&year=2026")
+        assert r.status_code == 422
+
+    def test_get_transactions_count_invalid_status_422(self, authorized_client):
+        """Invalid status value returns 422."""
+        r = authorized_client.get("/pegazzo/management/balance/transactions/count?status=INVALID")
+        assert r.status_code == 422
+
+    def test_get_transactions_count_unauthorized(self, client):
+        """Unauthenticated request returns 401."""
+        r = client.get("/pegazzo/management/balance/transactions/count")
+        assert r.status_code == 401
+
+    def test_get_transactions_count_reflects_mock_data(self, authorized_client):
+        """Count matches the number of mock transactions in the current month."""
+        from datetime import datetime, timezone
+
+        now = datetime.now(timezone.utc)
+        authorized_client.balance_repo.reset()
+        authorized_client.balance_repo.transactions = [
+            __import__("app.models.balance", fromlist=["Transaction"]).Transaction(
+                amount=100,
+                reference="CNT-001",
+                date=datetime(now.year, now.month, 5, 10, 0, tzinfo=timezone.utc),
+                type="debit",
+                description="Test",
+                payment_method="cash",
+                status="PENDING",
+                category="Otro",
+            ),
+            __import__("app.models.balance", fromlist=["Transaction"]).Transaction(
+                amount=200,
+                reference="CNT-002",
+                date=datetime(now.year, now.month, 10, 10, 0, tzinfo=timezone.utc),
+                type="debit",
+                description="Test 2",
+                payment_method="cash",
+                status="REJECTED",
+                category="Otro",
+            ),
+        ]
+
+        r = authorized_client.get("/pegazzo/management/balance/transactions/count")
+        assert r.status_code == 200
+        assert r.json()["count"] == 2

--- a/tests/unit/services/test_balance_service.py
+++ b/tests/unit/services/test_balance_service.py
@@ -827,3 +827,89 @@ class TestBalanceService:
 
         with pytest.raises(TransactionNotFoundException):
             self.service.authorize_transaction("NOEXIST", TransactionStatus.CONFIRMED, Role.OWNER)
+
+    # get_transactions_count tests
+
+    def test_get_transactions_count_defaults_to_current_month(self):
+        """No params → uses current month/year from datetime.now."""
+        start_dt = datetime(2026, 4, 1, 0, 0, 0, tzinfo=timezone.utc)
+        end_dt = datetime(2026, 4, 30, 23, 59, 59, tzinfo=timezone.utc)
+
+        self.mock_repo.count_transactions_in_range.return_value = 7
+
+        with patch("app.services.balance.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 4, 15, 10, 0, 0, tzinfo=timezone.utc)
+            with patch("app.services.balance.period_bounds_utc", return_value=(start_dt, end_dt)) as mock_bounds:
+                result = self.service.get_transactions_count()
+
+        key_arg = mock_bounds.call_args.args[0]
+        assert key_arg.year == 2026
+        assert key_arg.month == 4
+
+        assert result["count"] == 7
+        assert result["period"]["month"] == 4
+        assert result["period"]["year"] == 2026
+
+    def test_get_transactions_count_with_specific_month_year(self):
+        """Explicit month/year are forwarded to repo."""
+        start_dt = datetime(2025, 3, 1, 0, 0, 0, tzinfo=timezone.utc)
+        end_dt = datetime(2025, 3, 31, 23, 59, 59, tzinfo=timezone.utc)
+
+        self.mock_repo.count_transactions_in_range.return_value = 3
+
+        with patch("app.services.balance.period_bounds_utc", return_value=(start_dt, end_dt)) as mock_bounds:
+            result = self.service.get_transactions_count(month=3, year=2025)
+
+        key_arg = mock_bounds.call_args.args[0]
+        assert key_arg.year == 2025
+        assert key_arg.month == 3
+
+        self.mock_repo.count_transactions_in_range.assert_called_once_with(
+            start_dt=start_dt,
+            end_dt=end_dt,
+            status=None,
+        )
+        assert result["count"] == 3
+        assert result["period"] == {"month": 3, "year": 2025}
+
+    def test_get_transactions_count_with_status_filter(self):
+        """Status is passed through to repo."""
+        start_dt = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        end_dt = datetime(2026, 1, 31, 23, 59, 59, tzinfo=timezone.utc)
+
+        self.mock_repo.count_transactions_in_range.return_value = 2
+
+        with patch("app.services.balance.period_bounds_utc", return_value=(start_dt, end_dt)):
+            result = self.service.get_transactions_count(month=1, year=2026, status=TransactionStatus.PENDING)
+
+        self.mock_repo.count_transactions_in_range.assert_called_once_with(
+            start_dt=start_dt,
+            end_dt=end_dt,
+            status=TransactionStatus.PENDING,
+        )
+        assert result["count"] == 2
+
+    def test_get_transactions_count_no_status_counts_all(self):
+        """No status → status=None passed to repo (count all)."""
+        start_dt = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        end_dt = datetime(2026, 1, 31, 23, 59, 59, tzinfo=timezone.utc)
+
+        self.mock_repo.count_transactions_in_range.return_value = 15
+
+        with patch("app.services.balance.period_bounds_utc", return_value=(start_dt, end_dt)):
+            result = self.service.get_transactions_count(month=1, year=2026)
+
+        self.mock_repo.count_transactions_in_range.assert_called_once_with(
+            start_dt=start_dt,
+            end_dt=end_dt,
+            status=None,
+        )
+        assert result["count"] == 15
+
+    def test_get_transactions_count_repo_error_propagates(self):
+        """Unexpected repo error bubbles up."""
+        with patch("app.services.balance.period_bounds_utc", return_value=(datetime(2026, 1, 1, tzinfo=timezone.utc), datetime(2026, 1, 31, tzinfo=timezone.utc))):
+            self.mock_repo.count_transactions_in_range.side_effect = RuntimeError("DB down")
+
+            with pytest.raises(RuntimeError, match="DB down"):
+                self.service.get_transactions_count(month=1, year=2026)


### PR DESCRIPTION
## Ticket 🎫

### [PGZ-90: Create transactions count endpoint](https://kapibaras.atlassian.net/browse/PGZ-90)                                          

## Type of change ♻️

- [x] ✨ Feature
- [ ] 🐛 Bugfix
- [ ] ⚡️ Improvement
- [ ] 🔧 Chore

## What was done ❓

- Added `GET /management/balance/transactions/count` endpoint accessible by `OWNER` and `ADMIN` roles
- Added `TransactionCountQuerySchema` with optional `month`, `year` (must be provided together) and optional `status` filter
(`PENDING`, `CONFIRMED`, `REJECTED`); defaults to current month/year when no period is given
- Added `TransactionCountResponseSchema` returning `count` and `period` (`month`, `year`)
- Added `get_transactions_count()` method to `BalanceService` using the existing `count_transactions_in_range` repository method with 
month-based `period_bounds_utc`
- Added unit tests for service and router covering: default period, explicit month/year, each status value, no status (all), only     
month/only year → 400, invalid month/status → 422, unauthorized → 401
- Added Postman collection (`postman/PGZ-90_transactions_count.postman_collection.json`) with 11 requests covering happy path and     
error cases
- Created Alembic merge migration to resolve divergent `car_id` and `category` branch heads

## Checklist 📋

- [x] ⏭️ PR Branch has been **rebased** with `main`.
- [x] 🧪 Each change has a corresponding **Unit Test covering it**.
- [x] 🔎 Code and Functionality has been **self-reviewed** by the author.
- [x] 📝 PR Template has been **filled out**.
- [x] 🗃️ **Updated migrations** from changes on database schema. (If necessary)
- [x] ✏️ Endpoints and Schemas have complete and **well-written documentation**. (If necessary)
- [x] 📷 Evidence of changes on the endpoints (requests and response) (If necessary)

<img width="1061" height="970" alt="Captura de pantalla 2026-04-28 160234" src="https://github.com/user-attachments/assets/dd91f4ad-02bd-452e-931a-61ffac70af83" />
<img width="1128" height="760" alt="Captura de pantalla 2026-04-28 160215" src="https://github.com/user-attachments/assets/43fcf01c-eb43-4f23-a028-7e73c9c5709b" />
<img width="1086" height="833" alt="Captura de pantalla 2026-04-28 155925" src="https://github.com/user-attachments/assets/c5797c53-8038-415c-b8d9-98032c790e20" />
<img width="1092" height="863" alt="Captura de pantalla 2026-04-28 155915" src="https://github.com/user-attachments/assets/dd00fefe-1d6d-433e-96af-14319940079e" />
<img width="1137" height="789" alt="Captura de pantalla 2026-04-28 155859" src="https://github.com/user-attachments/assets/72cb1ded-ab6d-4506-a0ce-8053bc95fc67" />
