### PR TITLE
feat(crm): register CRM models and create base migrations [PGZ-119]

### DIFF
--- a/alembic/versions/d1e2f3a4b5c6_register_crm_models.py
+++ b/alembic/versions/d1e2f3a4b5c6_register_crm_models.py
@@ -1,0 +1,361 @@
+"""register CRM models and create base migrations
+
+Revision ID: d1e2f3a4b5c6
+Revises: bb39cb097284
+Create Date: 2026-07-02 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d1e2f3a4b5c6"
+down_revision: Union[str, Sequence[str], None] = "bb39cb097284"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create all CRM tables and fix transaction.car_id."""
+    # ------------------------------------------------------------------
+    # Tables with no FK dependencies
+    # ------------------------------------------------------------------
+    op.create_table(
+        "insurance",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=50), nullable=False),
+        sa.Column("telephones", postgresql.ARRAY(sa.String()), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "associate",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=50), nullable=False),
+        sa.Column("surnames", sa.String(length=100), nullable=False),
+        sa.Column("telephones", postgresql.ARRAY(sa.String()), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "document",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("type", sa.String(length=20), nullable=False),
+        sa.Column("url", sa.String(length=512), nullable=False),
+        sa.Column("category", sa.String(length=50), nullable=False),
+        sa.Column("confidence", sa.Numeric(5, 4), nullable=True),
+        sa.Column("extracted_fields", sa.JSON(), nullable=True),
+        sa.Column("expiry_date", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "reference",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=50), nullable=False),
+        sa.Column("surnames", sa.String(length=100), nullable=False),
+        sa.Column("telephones", postgresql.ARRAY(sa.String()), nullable=False),
+        sa.Column("relation", sa.String(length=10), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "guarantor",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=50), nullable=False),
+        sa.Column("surnames", sa.String(length=100), nullable=False),
+        sa.Column("telephones", postgresql.ARRAY(sa.String()), nullable=False),
+        sa.Column("address", sa.String(length=255), nullable=False),
+        sa.Column("relation", sa.String(length=10), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "scheduler",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("category", sa.String(length=20), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("interval", sa.String(length=20), nullable=False),
+        sa.Column("interval_count", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_launched_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # ------------------------------------------------------------------
+    # car — depends on insurance
+    # ------------------------------------------------------------------
+    op.create_table(
+        "car",
+        sa.Column("id", sa.String(length=15), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("make", sa.String(length=50), nullable=False),
+        sa.Column("model", sa.String(length=50), nullable=False),
+        sa.Column("year", sa.String(length=4), nullable=False),
+        sa.Column("color", sa.String(length=30), nullable=False),
+        sa.Column("body_type", sa.String(length=30), nullable=False),
+        sa.Column("engine_type", sa.String(length=30), nullable=False),
+        sa.Column("transmission", sa.String(length=20), nullable=False),
+        sa.Column("vin", sa.String(length=17), nullable=False),
+        sa.Column("engine_serial_number", sa.String(length=30), nullable=False),
+        sa.Column("plate", sa.String(length=10), nullable=False),
+        sa.Column("odometer", sa.Integer(), nullable=False),
+        sa.Column("doors_number", sa.Integer(), nullable=False),
+        sa.Column("passengers_number", sa.Integer(), nullable=False),
+        sa.Column("unit_value", sa.Numeric(12, 2), nullable=False),
+        sa.Column("unit_billing_value", sa.Numeric(12, 2), nullable=False),
+        sa.Column("bill_number", sa.String(length=30), nullable=False),
+        sa.Column("public_vehicle_registry", sa.String(length=30), nullable=False),
+        sa.Column("alta_public_vehicle_registry", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("tire_specification", sa.String(length=20), nullable=False),
+        sa.Column("features", sa.JSON(), nullable=False),
+        sa.Column("details", sa.JSON(), nullable=False),
+        sa.Column("legal_owner_name", sa.String(length=50), nullable=False),
+        sa.Column("legal_owner_surnames", sa.String(length=100), nullable=False),
+        sa.Column("battery_model", sa.String(length=20), nullable=False),
+        sa.Column("battery_serial_number", sa.String(length=30), nullable=False),
+        sa.Column("battery_date", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("policy_number", sa.String(length=30), nullable=False),
+        sa.Column("insurance_provider_id", sa.Integer(), nullable=False),
+        sa.Column("policy_expiration_date", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("policy_type", sa.String(length=20), nullable=False),
+        sa.Column("financed_status", sa.String(length=20), nullable=False),
+        sa.Column("agency_image", sa.String(length=512), nullable=True),
+        sa.Column("photos", postgresql.ARRAY(sa.String(length=512)), nullable=True),
+        sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["insurance_provider_id"], ["insurance.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("vin"),
+        sa.UniqueConstraint("plate"),
+    )
+
+    # ------------------------------------------------------------------
+    # driver — no FK deps (M2M tables come after)
+    # ------------------------------------------------------------------
+    op.create_table(
+        "driver",
+        sa.Column("id", sa.String(length=15), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("name", sa.String(length=50), nullable=False),
+        sa.Column("surnames", sa.String(length=100), nullable=False),
+        sa.Column("telephones", postgresql.ARRAY(sa.String(length=20)), nullable=False),
+        sa.Column("license_number", sa.String(length=20), nullable=False),
+        sa.Column("license_validity", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("identification_number", sa.String(length=20), nullable=False),
+        sa.Column("address", sa.String(length=255), nullable=False),
+        sa.Column("garage_address", postgresql.ARRAY(sa.String(length=255)), nullable=False),
+        sa.Column("photo", sa.String(length=512), nullable=True),
+        sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # ------------------------------------------------------------------
+    # M2M / junction tables — depend on their parent tables
+    # ------------------------------------------------------------------
+    op.create_table(
+        "associate_car",
+        sa.Column("associate_id", sa.Integer(), nullable=False),
+        sa.Column("car_id", sa.String(length=15), nullable=False),
+        sa.ForeignKeyConstraint(["associate_id"], ["associate.id"]),
+        sa.ForeignKeyConstraint(["car_id"], ["car.id"]),
+        sa.PrimaryKeyConstraint("associate_id", "car_id"),
+    )
+
+    op.create_table(
+        "car_document",
+        sa.Column("car_id", sa.String(length=15), nullable=False),
+        sa.Column("document_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["car_id"], ["car.id"]),
+        sa.ForeignKeyConstraint(["document_id"], ["document.id"]),
+        sa.PrimaryKeyConstraint("car_id", "document_id"),
+    )
+
+    op.create_table(
+        "guarantor_document",
+        sa.Column("guarantor_id", sa.Integer(), nullable=False),
+        sa.Column("document_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["guarantor_id"], ["guarantor.id"]),
+        sa.ForeignKeyConstraint(["document_id"], ["document.id"]),
+        sa.PrimaryKeyConstraint("guarantor_id", "document_id"),
+    )
+
+    op.create_table(
+        "reference_document",
+        sa.Column("reference_id", sa.Integer(), nullable=False),
+        sa.Column("document_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["reference_id"], ["reference.id"]),
+        sa.ForeignKeyConstraint(["document_id"], ["document.id"]),
+        sa.PrimaryKeyConstraint("reference_id", "document_id"),
+    )
+
+    op.create_table(
+        "driver_document",
+        sa.Column("driver_id", sa.String(length=15), nullable=False),
+        sa.Column("document_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["driver_id"], ["driver.id"]),
+        sa.ForeignKeyConstraint(["document_id"], ["document.id"]),
+        sa.PrimaryKeyConstraint("driver_id", "document_id"),
+    )
+
+    op.create_table(
+        "driver_reference",
+        sa.Column("driver_id", sa.String(length=15), nullable=False),
+        sa.Column("reference_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["driver_id"], ["driver.id"]),
+        sa.ForeignKeyConstraint(["reference_id"], ["reference.id"]),
+        sa.PrimaryKeyConstraint("driver_id", "reference_id"),
+    )
+
+    op.create_table(
+        "driver_guarantor",
+        sa.Column("driver_id", sa.String(length=15), nullable=False),
+        sa.Column("guarantor_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["driver_id"], ["driver.id"]),
+        sa.ForeignKeyConstraint(["guarantor_id"], ["guarantor.id"]),
+        sa.PrimaryKeyConstraint("driver_id", "guarantor_id"),
+    )
+
+    # ------------------------------------------------------------------
+    # contract and incidence — depend on car + driver
+    # ------------------------------------------------------------------
+    op.create_table(
+        "contract",
+        sa.Column("id", sa.String(length=15), nullable=False),
+        sa.Column("start_date", sa.Date(), nullable=False),
+        sa.Column("end_date", sa.Date(), nullable=False),
+        sa.Column("type", sa.String(length=10), nullable=False),
+        sa.Column("amount", sa.Numeric(12, 2), nullable=False),
+        sa.Column("guarantee_amount", sa.Numeric(12, 2), nullable=False),
+        sa.Column("sanction_amount", sa.Numeric(12, 2), nullable=True),
+        sa.Column("due_amount", sa.Numeric(12, 2), nullable=True),
+        sa.Column("signed_document_in", sa.String(length=512), nullable=True),
+        sa.Column("signed_document_out", sa.String(length=512), nullable=True),
+        sa.Column("signed_checklist_in", sa.String(length=512), nullable=True),
+        sa.Column("signed_checklist_out", sa.String(length=512), nullable=True),
+        sa.Column("car_id", sa.String(length=15), nullable=True),
+        sa.Column("driver_id", sa.String(length=15), nullable=True),
+        sa.ForeignKeyConstraint(["car_id"], ["car.id"]),
+        sa.ForeignKeyConstraint(["driver_id"], ["driver.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "incidence",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("type", sa.String(length=50), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False),
+        sa.Column("location", sa.String(length=255), nullable=True),
+        sa.Column("odometer", sa.Integer(), nullable=True),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("car_id", sa.String(length=15), nullable=True),
+        sa.Column("driver_id", sa.String(length=15), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["car_id"], ["car.id"]),
+        sa.ForeignKeyConstraint(["driver_id"], ["driver.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "incidence_document",
+        sa.Column("incidence_id", sa.Integer(), nullable=False),
+        sa.Column("document_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["incidence_id"], ["incidence.id"]),
+        sa.ForeignKeyConstraint(["document_id"], ["document.id"]),
+        sa.PrimaryKeyConstraint("incidence_id", "document_id"),
+    )
+
+    op.create_table(
+        "event",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("category", sa.String(length=20), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("car_id", sa.String(length=15), nullable=True),
+        sa.Column("driver_id", sa.String(length=15), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("to_resolve_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("accepted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["car_id"], ["car.id"]),
+        sa.ForeignKeyConstraint(["driver_id"], ["driver.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_table(
+        "event_document",
+        sa.Column("event_id", sa.Integer(), nullable=False),
+        sa.Column("document_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["event_id"], ["event.id"]),
+        sa.ForeignKeyConstraint(["document_id"], ["document.id"]),
+        sa.PrimaryKeyConstraint("event_id", "document_id"),
+    )
+
+    # ------------------------------------------------------------------
+    # Alter existing transaction.car_id: Integer → String(15) FK
+    # ------------------------------------------------------------------
+    op.alter_column(
+        "transaction",
+        "car_id",
+        existing_type=sa.Integer(),
+        type_=sa.String(length=15),
+        existing_nullable=True,
+        postgresql_using="car_id::text",
+    )
+    op.create_foreign_key(
+        "fk_transaction_car_id",
+        "transaction",
+        "car",
+        ["car_id"],
+        ["id"],
+    )
+
+
+def downgrade() -> None:
+    """Drop all CRM tables and revert transaction.car_id."""
+    # Revert transaction.car_id first (FK references car which we're dropping)
+    op.drop_constraint("fk_transaction_car_id", "transaction", type_="foreignkey")
+    op.alter_column(
+        "transaction",
+        "car_id",
+        existing_type=sa.String(length=15),
+        type_=sa.Integer(),
+        existing_nullable=True,
+        postgresql_using="car_id::integer",
+    )
+
+    # Drop in reverse dependency order
+    op.drop_table("event_document")
+    op.drop_table("event")
+    op.drop_table("incidence_document")
+    op.drop_table("incidence")
+    op.drop_table("contract")
+    op.drop_table("driver_guarantor")
+    op.drop_table("driver_reference")
+    op.drop_table("driver_document")
+    op.drop_table("reference_document")
+    op.drop_table("guarantor_document")
+    op.drop_table("car_document")
+    op.drop_table("associate_car")
+    op.drop_table("driver")
+    op.drop_table("car")
+    op.drop_table("scheduler")
+    op.drop_table("guarantor")
+    op.drop_table("reference")
+    op.drop_table("document")
+    op.drop_table("associate")
+    op.drop_table("insurance")

--- a/app/enum/__init__.py
+++ b/app/enum/__init__.py
@@ -1,4 +1,5 @@
 from .auth import Role
 from .balance import PaymentMethod, Type
+from .crm import CarStatus, DriverStatus
 
-__all__ = ["PaymentMethod", "Role", "Type"]
+__all__ = ["CarStatus", "DriverStatus", "PaymentMethod", "Role", "Type"]

--- a/app/enum/crm.py
+++ b/app/enum/crm.py
@@ -1,0 +1,17 @@
+from enum import StrEnum
+
+
+class CarStatus(StrEnum):
+    """Enum for car operational status."""
+
+    ACTIVE = "ACTIVE"
+    INACTIVE = "INACTIVE"
+    IN_MAINTENANCE = "IN_MAINTENANCE"
+
+
+class DriverStatus(StrEnum):
+    """Enum for driver operational status."""
+
+    ACTIVE = "ACTIVE"
+    INACTIVE = "INACTIVE"
+    SUSPENDED = "SUSPENDED"

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -17,36 +17,29 @@ from .incidence import Incidence, incidence_document_table
 from .users import Permission, Role, User, role_permission_table
 
 __all__ = [
-    # Users
-    "Role",
-    "User",
-    "Permission",
-    "role_permission_table",
-    # Balance
-    "Transaction",
-    # Car module
-    "Car",
-    "Insurance",
     "Associate",
-    "car_document_table",
-    "associate_car",
-    # Driver module
+    "Car",
+    "Contract",
+    "Document",
     "Driver",
-    "Reference",
+    "Event",
     "Guarantor",
+    "Incidence",
+    "Insurance",
+    "Permission",
+    "Reference",
+    "Role",
+    "Scheduler",
+    "Transaction",
+    "User",
+    "associate_car",
+    "car_document_table",
     "driver_document_table",
     "driver_guarantor_table",
     "driver_reference_table",
-    "guarantor_document_table",
-    "reference_document_table",
-    # Shared
-    "Document",
-    "Contract",
-    # Incidence
-    "Incidence",
-    "incidence_document_table",
-    # Event
-    "Event",
-    "Scheduler",
     "event_document_table",
+    "guarantor_document_table",
+    "incidence_document_table",
+    "reference_document_table",
+    "role_permission_table",
 ]

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,8 +1,52 @@
+from .balance import Transaction
+from .car import Associate, Car, Insurance, associate_car, car_document_table
+from .contract import Contract
+from .document import Document
+from .driver import (
+    Driver,
+    Guarantor,
+    Reference,
+    driver_document_table,
+    driver_guarantor_table,
+    driver_reference_table,
+    guarantor_document_table,
+    reference_document_table,
+)
+from .event import Event, Scheduler, event_document_table
+from .incidence import Incidence, incidence_document_table
 from .users import Permission, Role, User, role_permission_table
 
 __all__ = [
+    # Users
     "Role",
     "User",
     "Permission",
     "role_permission_table",
+    # Balance
+    "Transaction",
+    # Car module
+    "Car",
+    "Insurance",
+    "Associate",
+    "car_document_table",
+    "associate_car",
+    # Driver module
+    "Driver",
+    "Reference",
+    "Guarantor",
+    "driver_document_table",
+    "driver_guarantor_table",
+    "driver_reference_table",
+    "guarantor_document_table",
+    "reference_document_table",
+    # Shared
+    "Document",
+    "Contract",
+    # Incidence
+    "Incidence",
+    "incidence_document_table",
+    # Event
+    "Event",
+    "Scheduler",
+    "event_document_table",
 ]

--- a/app/models/balance.py
+++ b/app/models/balance.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Index, Integer, Numeric, String
+from sqlalchemy import Column, ForeignKey, Index, Integer, Numeric, String
 from sqlalchemy.sql import func
 from sqlalchemy.types import DateTime
 
@@ -17,6 +17,6 @@ class Transaction(Base):
     payment_method = Column(String(50), nullable=False)
     status = Column(String(10), nullable=False, default="PENDING")
     category = Column(String(100), nullable=True)
-    car_id = Column(Integer, nullable=True)
+    car_id = Column(String(15), ForeignKey("car.id"), nullable=True)
 
     __table_args__ = (Index("ix_transaction_date", "date"),)

--- a/app/models/car.py
+++ b/app/models/car.py
@@ -16,7 +16,7 @@ car_document_table = Table(
 associate_car = Table(
     "associate_car",
     Base.metadata,
-    Column("associate_id", String(15), ForeignKey("associate.id"), primary_key=True, nullable=False),
+    Column("associate_id", Integer, ForeignKey("associate.id"), primary_key=True, nullable=False),
     Column("car_id", String(15), ForeignKey("car.id"), primary_key=True, nullable=False),
 )
 
@@ -26,7 +26,7 @@ class Car(Base):
 
     __tablename__ = "car"
     id = Column(String(15), primary_key=True, nullable=False)
-    status = Column(String(10), nullable=False)
+    status = Column(String(20), nullable=False)
     make = Column(String(50), nullable=False)
     model = Column(String(50), nullable=False)
     year = Column(String(4), nullable=False)
@@ -48,8 +48,6 @@ class Car(Base):
     tire_specification = Column(String(20), nullable=False)
     features = Column(JSON, nullable=False)
     details = Column(JSON, nullable=False)
-    owner_name = Column(String(50), nullable=False)
-    owner_surnames = Column(String(100), nullable=False)
     legal_owner_name = Column(String(50), nullable=False)
     legal_owner_surnames = Column(String(100), nullable=False)
     associate = relationship("Associate", secondary=associate_car, back_populates="cars")
@@ -62,6 +60,9 @@ class Car(Base):
     policy_expiration_date = Column(DateTime(timezone=True), default=func.now(), nullable=False)
     policy_type = Column(String(20), nullable=False)
     financed_status = Column(String(20), nullable=False)
+    agency_image = Column(String(512), nullable=True)
+    photos = Column(ARRAY(String(512)), nullable=True)
+    archived_at = Column(DateTime(timezone=True), nullable=True)
     created_at = Column(DateTime(timezone=True), default=func.now(), nullable=False)
     updated_at = Column(DateTime(timezone=True), default=func.now(), onupdate=func.now(), nullable=False)
 

--- a/app/models/contract.py
+++ b/app/models/contract.py
@@ -14,7 +14,7 @@ class Contract(Base):
     end_date = Column(Date, nullable=False)
     type = Column(String(10), nullable=False)
     amount = Column(Numeric(12, 2), nullable=False)
-    gurantee_amount = Column(Numeric(12, 2), nullable=False)
+    guarantee_amount = Column(Numeric(12, 2), nullable=False)
     sanction_amount = Column(Numeric(12, 2), nullable=True)
     due_amount = Column(Numeric(12, 2), nullable=True)
     signed_document_in = Column(String(512), nullable=True)

--- a/app/models/document.py
+++ b/app/models/document.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, DateTime, Integer, String
+from sqlalchemy import JSON, Column, DateTime, Integer, Numeric, String
 from sqlalchemy.sql import func
 
 from app.database.base import Base
@@ -12,5 +12,9 @@ class Document(Base):
     id = Column(Integer, primary_key=True, nullable=False)
     type = Column(String(20), nullable=False)
     url = Column(String(512), nullable=False)
+    category = Column(String(50), nullable=False)
+    confidence = Column(Numeric(5, 4), nullable=True)
+    extracted_fields = Column(JSON, nullable=True)
+    expiry_date = Column(DateTime(timezone=True), nullable=True)
     created_at = Column(DateTime(timezone=True), default=func.now(), nullable=False)
     updated_at = Column(DateTime(timezone=True), default=func.now(), onupdate=func.now(), nullable=False)

--- a/app/models/driver.py
+++ b/app/models/driver.py
@@ -27,10 +27,10 @@ guarantor_document_table = Table(
     Column("document_id", Integer, ForeignKey("document.id"), primary_key=True, nullable=False),
 )
 
-references_document_table = Table(
-    "references_document",
+reference_document_table = Table(
+    "reference_document",
     Base.metadata,
-    Column("references_id", Integer, ForeignKey("references.id"), primary_key=True, nullable=False),
+    Column("reference_id", Integer, ForeignKey("reference.id"), primary_key=True, nullable=False),
     Column("document_id", Integer, ForeignKey("document.id"), primary_key=True, nullable=False),
 )
 
@@ -47,7 +47,7 @@ class Driver(Base):
 
     __tablename__ = "driver"
     id = Column(String(15), primary_key=True, nullable=False)
-    status = Column(String(10), nullable=False)
+    status = Column(String(20), nullable=False)
     name = Column(String(50), nullable=False)
     surnames = Column(String(100), nullable=False)
     telephones = Column(ARRAY(String(20)), nullable=False)
@@ -59,14 +59,16 @@ class Driver(Base):
     documents = relationship("Document", secondary=driver_document_table)
     guarantors = relationship("Guarantor", secondary=driver_guarantor_table)
     garage_address = Column(ARRAY(String(255)), nullable=False)
+    photo = Column(String(512), nullable=True)
+    archived_at = Column(DateTime(timezone=True), nullable=True)
     created_at = Column(DateTime(timezone=True), default=func.now(), nullable=False)
     updated_at = Column(DateTime(timezone=True), default=func.now(), onupdate=func.now(), nullable=False)
 
 
 class Reference(Base):
-    """References model class."""
+    """Reference model class."""
 
-    __tablename__ = "references"
+    __tablename__ = "reference"
     id = Column(Integer, primary_key=True, nullable=False)
     name = Column(String(50), nullable=False)
     surnames = Column(String(100), nullable=False)


### PR DESCRIPTION
## Ticket 🎫

### [PGZ-119: [MTH] Register CRM models and create base migrations](https://kapibaras.atlassian.net/browse/PGZ-119)

## Type of change ♻️

- [x] ✨ Feature
- [ ] 🐛 Bugfix
- [x] ⚡️ Improvement
- [ ] 🔧 Chore

## What was done ❓

- Registered all CRM models in `app/models/__init__.py` so Alembic detects them via `from app.models import *`
- Authored Alembic migration `d1e2f3a4b5c6` that creates all 20 CRM tables (`car`, `driver`, `reference`, `guarantor`, `insurance`, `associate`, `document`, `contract`, `incidence`, `event`, `scheduler` and their M2M junction tables)
- Fixed model inconsistencies: canonicalized `reference` table name, widened `status` columns to `String(20)`, fixed `Contract.guarantee_amount` typo, converted `transaction.car_id` to `String(15)` FK, fixed `associate_car.associate_id` type to `Integer`, removed redundant `Car.owner_name`/`owner_surnames`
- Added new fields: `Car.archived_at`, `Car.agency_image`, `Car.photos`; `Driver.archived_at`, `Driver.photo`; `Document.category`, `Document.confidence`, `Document.extracted_fields`, `Document.expiry_date`
- Added `CarStatus` and `DriverStatus` enums in `app/enum/crm.py`

## Checklist 📋

- [x] ⏭️ PR Branch has been **rebased** with `main`.
- [ ] 🧪 Each change has a corresponding **Unit Test covering it**.
- [x] 🔎 Code and Functionality has been **self-reviewed** by the author.
- [x] 📝 PR Template has been **filled out**.
- [x] 🗃️ **Updated migrations** from changes on database schema. (If necessary)
- [ ] ✏️ Endpoints and Schemas have complete and **well-written documentation**. (If necessary)
- [x] 📷 Evidence of changes on the endpoints (requests and response) (If necessary)

<img width="447" height="656" alt="Captura de pantalla 2026-07-03 132516" src="https://github.com/user-attachments/assets/057843e2-c5ec-471e-a6c6-839844056d0c" />