### PR TITLE
[OPS] Fix shell expansion of special chars in registry password - PGZ-104

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,20 +15,28 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Log in to container registry
+        env:
+          REGISTRY_URL: ${{ secrets.REGISTRY_URL }}
+          REGISTRY_USER: ${{ secrets.REGISTRY_USER }}
+          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
         run: |
-          echo "${{ secrets.REGISTRY_PASSWORD }}" | docker login "${{ secrets.REGISTRY_URL }}" \
-            -u "${{ secrets.REGISTRY_USER }}" --password-stdin
+          echo "$REGISTRY_PASSWORD" | docker login "$REGISTRY_URL" \
+            -u "$REGISTRY_USER" --password-stdin
 
       - name: Preserve previous image for rollback
+        env:
+          REGISTRY_URL: ${{ secrets.REGISTRY_URL }}
         run: |
-          IMAGE="${{ secrets.REGISTRY_URL }}/pegazzo-monolith"
+          IMAGE="$REGISTRY_URL/pegazzo-monolith"
           docker pull "$IMAGE:main" || true
           docker tag "$IMAGE:main" "$IMAGE:previous" || true
           docker push "$IMAGE:previous" || true
 
       - name: Build and push Docker image
+        env:
+          REGISTRY_URL: ${{ secrets.REGISTRY_URL }}
         run: |
-          IMAGE="${{ secrets.REGISTRY_URL }}/pegazzo-monolith:main"
+          IMAGE="$REGISTRY_URL/pegazzo-monolith:main"
           docker build -t "$IMAGE" .
           docker push "$IMAGE"
 
@@ -67,5 +75,7 @@ jobs:
 
     steps:
       - name: Trigger Dokploy staging webhook
+        env:
+          WEBHOOK_URL: ${{ secrets.DOKPLOY_MONOLITH_STAGING_WEBHOOK }}
         run: |
-          curl -fsSL -X POST "${{ secrets.DOKPLOY_MONOLITH_STAGING_WEBHOOK }}"
+          curl -fsSL -X POST "$WEBHOOK_URL"


### PR DESCRIPTION
## Ticket 🎫

### [PGZ-104: Build & Deploy Staging Pipeline](https://kapibaras.atlassian.net/browse/PGZ-104)

## Type of change ♻️

- [ ] ✨ Feature
- [ ] 🐛 Bugfix
- [x] ⚡️ Improvement
- [ ] 🔧 Chore

## What was done ❓

- Pass registry secrets as `env:` variables in `build.yml` instead of inline `${{ secrets.* }}` substitution
- Prevents bash from expanding `$$` in the password to the process PID, which caused `401 Unauthorized` on `docker login`
- Same fix applied to the Dokploy webhook URL

## Checklist 📋

- [x] ⏭️ PR Branch has been **rebased** with `main`.
- [x] 🧪 Each change has a corresponding **Unit Test covering it**.
- [x] 🔎 Code and Functionality has been **self-reviewed** by the author.
- [x] 📝 PR Template has been **filled out**.
- [ ] 🗃️ **Updated migrations** from changes on database schema. (If necessary)
- [ ] ✏️ Endpoints and Schemas have complete and **well-written documentation**. (If necessary)
- [ ] 📷 Evidence of changes on the endpoints (requests and response) (If necessary)